### PR TITLE
fix: Restore store_fulfillment and store_resolver to core.extension.yml

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -108,6 +108,8 @@ module:
   scheduler: 0
   scheduler_content_moderation_integration: 0
   state_machine: 0
+  store_fulfillment: 0
+  store_resolver: 0
   svg_image: 0
   symfony_mailer_lite: 0
   system: 0


### PR DESCRIPTION
## Problem
The last merge (PR #4) accidentally removed `store_fulfillment` and `store_resolver` from `core.extension.yml`, causing:

```
Error: Call to a member function getPath() on null in Drupal\navigation\EntityRouteHelper->getContentEntityFromRoute()
```

when visiting `/admin/commerce/config/store-fulfillment`.

## Fix
Re-added both modules to `config/sync/core.extension.yml`.

## Testing
- `ddev drush cim` — successfully re-installed `store_fulfillment`
- Both modules confirmed enabled via `ddev drush pm:list`
- Route `/admin/commerce/config/store-fulfillment` resolves correctly