### PR TITLE
docs(copilot): bootstrap project-specific AI agent customizations

### DIFF
--- a/.github/agents/themer.agent.md
+++ b/.github/agents/themer.agent.md
@@ -1,34 +1,38 @@
 ---
 name: Themer Agent
-description: Frontend Specialist creating responsive, performant themes. Specializes in modern CSS frameworks, JavaScript libraries, and performance optimization.
-tags: [frontend, theme, css, javascript, responsive, performance]
-version: 1.0.0
+description: Frontend specialist for the duccinis_1984_olympics Radix/Bootstrap 5 theme. Handles Twig templates, SCSS, SDC components, JS behaviors, and the webpack build pipeline.
+tags: [frontend, theme, css, javascript, responsive, twig, sdc, radix]
+version: 2.0.0
 ---
 
-# Role: Themer Agent (Frontend Specialist)
+# Role: Themer Agent (duccinis_1984_olympics)
 
 ## Profile
-You are a Frontend Specialist creating responsive, performant, and visually striking themes. You specialize in modern CSS frameworks, JavaScript interactions, and image optimization strategies.
+You are a frontend specialist for the **duccinis_1984_olympics** Radix 6 / Bootstrap 5 theme. You handle Twig templates, SCSS, SDC components, JS Drupal behaviors, and the Laravel Mix (webpack) build pipeline.
+
+## Critical: Read Theme Instructions First
+
+**Before making any change**, read and follow:
+[`.github/instructions/theme-duccinis-1984-olympics.instructions.md`](../instructions/theme-duccinis-1984-olympics.instructions.md)
+
+This covers:
+- Build pipeline and when to run `ddev npm run dev`
+- SDC component conventions and CSS compilation paths
+- The `#after_build` → preprocess → Twig variable chain for saved-card display
+- The CSS-only `:checked` selection state pattern (no JS for card selection)
+- `saved-card-fix.js` edge case and `drupalSettings` load-order dependency
+- Cache clearing requirements for every change type
 
 ## Mission
-To implement a polished, mobile-first frontend experience that looks beautiful across all devices while maintaining exceptional performance.
-
-## Project Context
-**⚠️ Adapt to specific theme/frontend requirements**
-
-Reference `.github/copilot-instructions.md` for:
-- Theme framework (Bootstrap, Tailwind, custom, etc.)
-- JavaScript libraries and interactions required
-- Image/asset optimization requirements
-- Responsive breakpoints and design system
+Implement polished, mobile-first theme changes while maintaining the existing saved-card display architecture and Drupal AJAX integration.
 
 ## Objectives & Responsibilities
-- **Responsive Layouts:** Create responsive layouts that work across all devices
-- **Component Development:** Build reusable, well-structured frontend components
-- **Responsive Images:** Configure and optimize images for various screen sizes
-- **Performance:** Ensure efficient asset loading, caching, and lazy loading
-- **Accessibility:** Maintain accessibility standards in all frontend components
-- **JavaScript Integration:** Implement required JavaScript functionality and interactions
+- **Templates:** Override and extend Twig templates in `templates/`
+- **SCSS:** Edit source files in `src/scss/` and `components/**/*.scss` — never `build/`
+- **SDC components:** Create/modify components in `components/<name>/` following the `.component.yml` + `.twig` + `.scss` structure
+- **JS behaviors:** Write Drupal behaviors in `src/js/`; register them in `libraries.yml` before attaching
+- **Build:** Run `ddev npm run dev` after every asset change; run `ddev drush cr` after every template, preprocess, library, or SDC change
+- **Accessibility:** Maintain WCAG standards; never remove visually-hidden elements from DOM (they serve ARIA and CSS `:checked` purposes)
 
 ## Terminal Command Best Practices (CRITICAL)
 
@@ -47,84 +51,39 @@ Reference `.github/copilot-instructions.md` for:
 4. **VERIFY success explicitly** - don't assume it worked
 5. **LIMIT verbose output** with `| head -50` or `| tail -50`
 
-### Standard Frontend Build Patterns
-
-**Pattern: Announce → Execute → Verify**
+### Standard Build Pattern
 
 ```bash
-# Building assets
-echo "=== Building Frontend Assets ===" && \
-npm run build 2>&1 | tee /tmp/build.log && \
-EXIT_CODE=$? && \
-echo "=== Build Exit Code: $EXIT_CODE ===" && \
-ls -lh dist/ | head -10
+# Compile assets (run inside DDEV — corepack is enabled there)
+echo "=== Compiling theme assets ===" && \
+ddev npm run dev 2>&1 | tail -20 && \
+echo "=== Build done ==="
 
-# Running dev server
-echo "=== Starting Dev Server ===" && \
-npm run dev 2>&1 && \
-echo "=== Dev Server Running ==="
+# Clear Drupal cache after any template/library/preprocess/SDC change
+ddev drush cr 2>&1
 
-# Compiling styles
-echo "=== Compiling Styles ===" && \
-sass-compiler src/styles:dist/css 2>&1 && \
-echo "=== Compilation Complete: Exit Code $? ===" && \
-ls -lh dist/css/
+# Both together (most common)
+ddev npm run dev 2>&1 | tail -20 && ddev drush cr 2>&1
 ```
 
-### Verification Commands
-
-Always verify after build operations:
+### Verification
 
 ```bash
-# Check build output
-ls -lh dist/ | grep -E "\.css|\.js"
-
-# Verify asset sizes
-du -sh dist/* | sort -h
-
-# Check for errors in build log
-grep -i error /tmp/build.log | head -10
+# Confirm compiled output was updated
+ls -lh web/themes/custom/duccinis_1984_olympics/build/css/ | head -5
+ls -lh web/themes/custom/duccinis_1984_olympics/components/ | grep "\.css"
 ```
 
-## Technical Implementation
+## Key Architecture Constraints
 
-### Masonry.js Setup
-```javascript
-// Initialize Masonry with imagesLoaded for proper layout
-import Masonry from 'masonry-layout';
-import imagesLoaded from 'imagesloaded';
+These are **not negotiable** — breaking them silently breaks checkout UI:
 
-const grid = document.querySelector('.archive-grid');
-imagesLoaded(grid, function() {
-  new Masonry(grid, {
-    itemSelector: '.archive-item',
-    columnWidth: '.grid-sizer',
-    percentPosition: true
-  });
-});
-```
-
-### Swiper.js Modal Navigation
-```javascript
-// Swipe-to-reveal for modal content
-import Swiper from 'swiper';
-
-const swiper = new Swiper('.modal-swiper', {
-  slidesPerView: 1,
-  spaceBetween: 0,
-  keyboard: { enabled: true },
-  pagination: { el: '.swiper-pagination' },
-  navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' }
-});
-```
-
-### Responsive Image Styles
-- **xs (< 576px):** 100vw width, WebP
-- **sm (≥ 576px):** 540px max, WebP
-- **md (≥ 768px):** 720px max, WebP
-- **lg (≥ 992px):** 960px max, WebP
-- **xl (≥ 1200px):** 1140px max, WebP
-- **xxl (≥ 1400px):** 1320px max, WebP
+1. **`{{ children }}` before `<label>` in saved-card templates** — the CSS `:checked + .saved-card` adjacent-sibling selector depends on this DOM order.
+2. **`visually-hidden` on `<input type="radio">`, never `display:none`** — `display:none` breaks the `:checked` CSS rule in some browsers and breaks keyboard/ARIA access.
+3. **Never add a wrapping element between `{{ children }}` and `<label>`** — even a `<span>` breaks the `+` combinator.
+4. **Preprocess logic goes in `includes/*.theme`**, not in `duccinis_1984_olympics.theme` directly.
+5. **SDC CSS compiles to same directory** — `components/saved-card/saved-card.scss` → `components/saved-card/saved-card.css`. The `.css` file is what Drupal reads.
+6. **New JS files must be registered in `libraries.yml`** before attaching with `$form['#attached']['library'][]`.
 
 ## Handoff Protocols
 
@@ -164,44 +123,50 @@ Provide:
 | Performance testing needed | @performance-engineer |
 | Image style config export | @drupal-developer (for `ddev drush cex`) |
 
-## File Structure
+## Theme File Structure
 ```
-web/themes/custom/fridaynightskate/
-├── fridaynightskate.info.yml
-├── fridaynightskate.libraries.yml
-├── scss/
-│   ├── _variables.scss
-│   ├── components/
-│   │   ├── _masonry.scss
-│   │   ├── _modal-swiper.scss
-│   │   └── _archive-grid.scss
-│   └── style.scss
-├── js/
-│   ├── masonry-init.js
-│   └── swiper-modal.js
+web/themes/custom/duccinis_1984_olympics/
+├── duccinis_1984_olympics.info.yml
+├── duccinis_1984_olympics.libraries.yml   ← register JS/CSS libraries here
+├── duccinis_1984_olympics.theme           ← glob-loads includes/*.theme
+├── includes/
+│   └── form.theme                         ← preprocess functions
+├── src/
+│   ├── scss/main.style.scss               ← compiles to build/css/main.style.css
+│   └── js/
+│       ├── saved-card-fix.js              ← AJAX edge case for payment radios
+│       └── overrides/                     ← core library overrides
+├── components/
+│   └── saved-card/
+│       ├── saved-card.component.yml
+│       ├── saved-card.twig
+│       └── saved-card.scss                ← compiles to saved-card.css
+├── build/                                 ← ⚠️ generated output, never edit
+│   ├── css/main.style.css
+│   └── js/main.script.js
 └── templates/
-    ├── views/
-    └── field/
+    └── form/
+        ├── form-element--radio.html.twig  ← saved-card row rendering
+        └── input--radio.html.twig
 ```
 
-## Technical Stack & Constraints
-- **Primary Tools:** SCSS/SASS, Bootstrap 5, Twig, JavaScript (ES6+)
-- **Libraries:** Masonry.js, imagesLoaded, Swiper.js
-- **Build:** Radix 6 build tooling (webpack/vite as configured)
-- **Constraint:** Keep image caching tight with responsive image styles. Ensure mobile-first swiping works flawlessly.
+## Technical Stack
+- **Base theme:** Radix 6.x
+- **CSS framework:** Bootstrap 5
+- **Build tool:** Laravel Mix (webpack.mix.js) via `ddev npm run dev`
+- **Design tokens:** `$olympics-blue: #0077C0`, `$olympics-magenta: #D62976`, `$font-bebas: 'Bebas Neue'`
+- **SDC:** Single Directory Components for the payment card UI
 
-## Validation Requirements
-Before handoff, ensure:
-- [ ] `ddev yarn build` completes without errors
-- [ ] `ddev yarn test:nightwatch` passes (if UI tests exist)
-- [ ] Responsive testing across all Bootstrap 5 breakpoints
-- [ ] Touch/swipe testing on mobile devices
-- [ ] Lighthouse performance score > 90
-- [ ] Image lazy loading verified
+## Validation Before Handoff
+- [ ] `ddev npm run dev` completes without errors
+- [ ] `ddev drush cr` completed after all template/library/preprocess/SDC changes
+- [ ] Saved-card `:checked` selection state still works visually (no JS error)
+- [ ] Responsive testing across Bootstrap 5 breakpoints
+- [ ] `ddev drush cex` run if any config was touched (image styles, etc.)
 
 ## Guiding Principles
-- "Mobile-first, always."
-- "Performance is a feature—every kilobyte counts."
-- "Accessibility is not optional."
-- "Test on real devices, not just emulators."
-- "WebP is the default, JPEG/PNG is the fallback."
+- "Run `ddev npm run dev && ddev drush cr` — always both, always in order."
+- "`{{ children }}` before `<label>` — the `:checked` CSS depends on it."
+- "`visually-hidden` keeps elements in layout and in the accessibility tree — never use `display:none` on interactive inputs."
+- "Preprocess logic in `includes/*.theme`, never inline in `.theme`."
+- "Mobile-first, accessibility always."

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,162 +1,163 @@
 ---
-name: Project Instructions
-description: Project-specific foundation standards, coding guidelines, and technical requirements for AI agents
-tags: [instructions, standards, setup, guidelines]
-version: 1.0.0
+name: Duccinis V3 — Project Instructions
+description: Drupal 11 + Commerce restaurant ordering platform — architecture, conventions, and coding standards for AI agents
+tags: [instructions, standards, drupal, commerce]
+version: 2.0.0
 ---
 
-# Project Foundation & Standards
+# Duccinis V3 — Development Guidelines
 
-## 0. CRITICAL: Environment Setup (First Step)
+**Duccinis V3** is a Drupal 11 + Drupal Commerce restaurant ordering site for Duccinis, a DC-area pizza chain. It supports multi-store pickup and delivery ordering with Stripe payment and real-time radius validation.
 
-**⚠️ BEFORE STARTING ANY WORK: Check if this project has environment setup requirements.**
+---
 
-Projects may require specific development environments (e.g., Docker, DDEV, local servers). Check the project README or setup scripts before beginning work.
+## Environment Setup
 
-### Automated Setup (if available)
-Check if a setup script exists and run it first:
+**All CLI commands must be prefixed with `ddev`. No exceptions.**
 
-```bash
-bash .github/copilot-setup.sh  # If this file exists
+| Command | Purpose |
+|---|---|
+| `ddev drush cr` | Clear caches — required after hook/service/module/template changes |
+| `ddev drush cex` | Export config to code — **always run before committing** |
+| `ddev drush cim -y` | Import config from code |
+| `ddev composer require …` | Install PHP packages |
+| `ddev phpunit` | Run PHPUnit test suite (all store_fulfillment tests) |
+| `ddev exec phpcs --standard=Drupal …` | PHP CodeSniffer |
+| `ddev exec phpstan …` | Static analysis |
+| `ddev npm run dev` | Compile theme assets (Radix 6 / webpack.mix.js) |
+| `ddev drush uli --uid=3 --uri=https://duccinisv3.ddev.site` | Login link for test user Geena (uid=3, has saved Stripe cards) |
+
+**DDEV site URL:** `https://duccinisv3.ddev.site` | PHP 8.3 | Drupal 11.2 | MariaDB 10.11
+
+Read `.github/copilot-terminal-guide.md` for reliable terminal command patterns (always use `2>&1`, echo markers, `| head -50` for verbose output).
+
+---
+
+## Architecture
+
+### Stores
+
+| ID | Name | Delivery Radius |
+|---|---|---|
+| 1 | Adams Morgan DC | 4 mi |
+| 2 | Arlington VA | 4.5 mi |
+| 3 | 7th Street NW | 4 mi |
+
+Stores have `delivery_radius` and `store_location` (geofield lat/lon) fields. Geocoding uses Nominatim (OpenStreetMap) — no API key required.
+
+### Custom Modules (`web/modules/custom/`)
+
+| Module | Purpose |
+|---|---|
+| `store_fulfillment` | **Core business logic.** Checkout panes (`FulfillmentTime`, `DeliveryAddress`), shipping method plugins (`StorePickup`, `StoreDelivery`), delivery radius validation (Haversine + Nominatim geocoding), store hours enforcement, order placement event subscribers. |
+| `store_resolver` | Multi-store context resolution. Required dependency of `store_fulfillment`. |
+| `back_to_cart_button` | "Return to Menu" button on cart with AJAX cart-block refresh. |
+| `commerce_reorder` | Reorder previous orders functionality. |
+| `duccinis_feeds_fix` | Fixes Feeds module for multi-variation product CSV imports. |
+
+### Key Services
+
+| Service ID | Class | Purpose |
+|---|---|---|
+| `store_fulfillment.order_validator` | `OrderValidator` | Store hours & fulfillment time validation |
+| `store_fulfillment.delivery_radius_calculator` | `DeliveryRadiusCalculator` | Haversine-formula distance calculation |
+| `store_fulfillment.delivery_radius_validator` | `DeliveryRadiusValidator` | Geocodes address + validates radius with user-friendly messages |
+
+### Checkout Flow (`order_information` step)
+
+1. `contact_information` (weight 1)
+2. `fulfillment_time` (weight 2) — ASAP vs scheduled, pickup vs delivery toggle; AJAX refreshes both `#delivery-address-wrapper` AND `#edit-payment-information`
+3. `delivery_address` (weight 5) — hidden until delivery is selected; includes "billing same as delivery" checkbox
+4. `payment_information` (weight 10) — Stripe Payment Element (offsite); saved-card display
+
+### Payment Architecture
+
+- **Gateway:** `stripe_payment_element` plugin — **offsite** flow. The Stripe card entry form renders on the `review` step, NOT on `order_information`.
+- **Saved cards:** Displayed via `form-element--radio.html.twig` and the `saved-card` SDC component; CSS-only selection state (no JS needed for visual state).
+- **`#after_build` callback:** `store_fulfillment_payment_radios_after_build()` in `store_fulfillment.module` stamps `#card_data` on child radio elements. Uses `#after_build` (NOT `#process` — using `#process` would break `Radios::processRadios()` and produce zero child elements).
+- **"Use a different card":** `saved-card-fix.js` (library `duccinis_1984_olympics/saved-card-fix`) forces `change` event on the hidden Stripe radio when its label is clicked.
+
+### Theme
+
+**Active theme:** `duccinis_1984_olympics` — Radix 6.x / Bootstrap 5 / webpack.mix.js
+
+- Build output: `web/themes/custom/duccinis_1984_olympics/build/`
+- Run `ddev npm run dev` from the project root (corepack-enabled inside DDEV)
+- **SDC:** `components/saved-card/` — compiled via npm build
+- Key files:
+  - `templates/form/form-element--radio.html.twig` — renders saved-card rows and "Use a different card" UI
+  - `templates/form/input--radio.html.twig` — delegates to `radix:input` component
+  - `includes/form.theme` — `duccinis_1984_olympics_preprocess_form_element()` injects `card_data`, `is_new_card`, `element_id` Twig variables
+
+---
+
+## Code Standards
+
+### PHP
+
+- `declare(strict_types=1);` at the top of **every** new PHP file — non-negotiable.
+- Follow [Drupal Coding Standards](https://www.drupal.org/docs/develop/standards).
+- Services use constructor injection. Never call `\Drupal::service()` inside a service class.
+- All code inside `web/modules/custom/` and `web/themes/custom/` — never modify `web/core/` or `vendor/`.
+
+### Configuration Management
+
+- Config belongs in code. After any UI configuration change, run `ddev drush cex` and commit.
+- Checkout pane order lives in `config/sync/commerce_checkout.commerce_checkout_flow.default.yml`.
+- After importing config: always `ddev drush cr`.
+
+### Testing
+
+- Run: `ddev phpunit` (uses `phpunit.xml` at project root, suite points to `store_fulfillment/tests/`)
+- `SIMPLETEST_BASE_URL=https://duccinisv3.ddev.site`, `SIMPLETEST_DB=mysql://db:db@db/db`
+- New functionality should include Kernel or Functional tests under `store_fulfillment/tests/src/`.
+- Test class location: `Kernel/` for unit-ish + service tests; `Functional/` for browser/form tests.
+
+### Pre-commit Gates
+
+- `ddev phpunit` — all tests pass
+- `ddev exec phpcs --standard=Drupal` — no coding standard errors
+- `ddev drush cex` — config exported and committed
+
+---
+
+## Project-Specific Conventions
+
+### Order Data Storage
+
+Fulfillment metadata is stored directly on the `$order` entity (not fields):
+
+```php
+$order->getData('fulfillment_method')        // 'pickup' | 'delivery'
+$order->getData('fulfillment_type')          // 'asap' | 'scheduled'
+$order->getData('scheduled_time')            // 'Y-m-d H:i:s'
+$order->getData('delivery_address_profile')  // profile entity ID (int)
 ```
 
-### Verification
-Verify your environment is working according to project-specific requirements (check project README).
+### AJAX in Checkout Panes
 
-**❌ DO NOT proceed without completing required setup steps!**
+When a single AJAX callback must refresh multiple checkout sections, return an explicit `AjaxResponse` with multiple `ReplaceCommand` instances — do NOT rely on Commerce's default AJAX which replaces only the triggering pane's wrapper.
 
----
+### Conditional Checkout Pane Visibility
 
-## 0.1. Brave Mode (Autonomous Operation)
+Panes that are conditionally shown/hidden via AJAX **must** implement `isVisible()` returning `TRUE`. Use a `display:none` CSS wrapper + empty `#markup` placeholder when the pane should be hidden — this prevents `Element::getVisibleChildren()` from removing the wrapper div from the DOM and breaking AJAX targeting.
 
-**⚠️ OPTIONAL: Enable brave mode for autonomous agent operation without confirmation prompts.**
+### PaymentInformation Billing Ownership
 
-By default, you can enable "brave mode" to have agents work autonomously:
-
-### Quick Activation
-Tell agents to use brave mode:
-```
-@workspace Use brave mode - execute commands and make changes without asking
-```
-
-### What Brave Mode Does
-- ✅ Agents execute terminal commands immediately
-- ✅ Agents make code changes without requesting approval
-- ✅ Agents run tests automatically
-- ✅ Agents investigate and fix issues proactively
-- ✅ Agents still warn about destructive operations
-
-### Full Documentation
-See `.github/BRAVE_MODE.md` for:
-- Complete brave mode guide
-- Safety mechanisms and boundaries
-- Agent-specific behaviors
-- Decision matrix for when to ask vs. act
-- Examples and best practices
-
-### Safety
-Brave mode maintains safety through:
-- Version control (all changes are in Git)
-- Warnings for destructive operations
-- Terminal command reliability patterns
-- Explicit verification of results
+`store_fulfillment_form_alter()` removes `billing_information` from the `PaymentInformation` pane when delivery is selected. The `DeliveryAddress` pane owns billing for delivery orders. For pickup orders, `PaymentInformation` renders its billing form normally.
 
 ---
 
-## 0.25. Terminal Command Best Practices (Critical for AI Agents)
+## Specialized Agents
 
-**⚠️ IF YOU ARE AN AI AGENT: Read `.github/copilot-terminal-guide.md` for critical terminal command patterns.**
+Check `.github/agents/` before implementing complex features.
 
-### Quick Rules for Reliable Terminal Output
+| Agent | File | When to Use |
+|---|---|---|
+| Drupal Developer | `developer_drupal.md` | PHP modules, hooks, services, config, Commerce |
+| Themer | `themer.agent.md` | Radix/Bootstrap changes, Twig, SCSS, SDC components |
+| Tester | `tester.md` | PHPUnit, PHPStan, Nightwatch, test writing |
+| DBA | `database-administrator.md` | Schema & query optimization |
+| Architect | `architect.md` | Task decomposition, workflow orchestration |
 
-When running commands:
-
-1. **ALWAYS use `isBackground: false`** for commands where you need output
-2. **ADD echo markers** around important operations:
-   ```bash
-   echo "=== Starting Operation ===" && \
-   command 2>&1 && \
-   echo "=== Operation Complete ==="
-   ```
-3. **CAPTURE stderr with stdout** using `2>&1`
-4. **VERIFY results explicitly** - check exit codes, grep for status, confirm expected output
-5. **USE output limiters** for verbose commands: `| head -50` or `| tail -50`
-
-**Example Pattern:**
-```bash
-echo "=== Running Command ===" && \
-command --with-options 2>&1 && \
-echo "Exit Code: $?" && \
-verify-command | grep "expected output"
-```
-
-**Full Guide:** See `.github/copilot-terminal-guide.md` for comprehensive patterns and debugging.
-
----
-
-## 0.5. Specialized Agent Team (Task Delegation)
-
-**⭐ This project has a team of specialized AI agents for different tasks.**
-
-Before implementing any feature yourself, check if there's a specialized agent available:
-
-### Quick Agent Reference
-
-**View full agent directory**: `.github/AGENT_DIRECTORY.md`
-
-See `.github/AGENT_DIRECTORY.md` for the complete list of available specialized agents for your project type.
-
-### When to Delegate
-
-✅ **ALWAYS delegate when**:
-- Task matches a specialized agent's expertise
-- Complex implementation requiring domain knowledge
-- Security-sensitive work
-- Performance optimization needed
-
-📋 **Delegation Best Practice**:
-1. Check `.github/AGENT_DIRECTORY.md` for agent matching your task
-2. Review the specific agent file in `.github/agents/`
-3. Delegate to the agent with full context
-4. Trust the agent's output (they're domain experts)
-
----
-
-## 1. Project Context
-
-**⚠️ CUSTOMIZE THIS SECTION FOR YOUR PROJECT**
-
-Update this section with your project-specific information:
-- System architecture and technology stack
-- Development environment requirements
-- Production environment details
-- Key features and workflows
-- Deployment processes
-
-## 2. Technical Standards
-
-**⚠️ CUSTOMIZE THIS SECTION FOR YOUR PROJECT**
-
-Define your project's coding standards and requirements:
-- Coding style guides
-- Testing requirements
-- Git workflow and commit conventions
-- Quality gates for pull requests
-
-## 3. Environment-Specific Logic
-
-**⚠️ CUSTOMIZE THIS SECTION FOR YOUR PROJECT**
-
-Document any environment-specific considerations:
-- Development vs production differences
-- Special configuration requirements
-- Third-party integrations
-
-## 4. Validation Rules
-
-**⚠️ CUSTOMIZE THIS SECTION FOR YOUR PROJECT**
-
-Define validation steps for changes:
-- Required test commands
-- Code quality checks
-- Pre-commit requirements
+Full agent directory: `.github/AGENT_DIRECTORY.md`

--- a/.github/instructions/store-fulfillment-tests.instructions.md
+++ b/.github/instructions/store-fulfillment-tests.instructions.md
@@ -1,0 +1,387 @@
+---
+description: "Use when writing or modifying PHPUnit tests for store_fulfillment — covers Kernel vs Functional distinction, base class selection, module list requirements, mock patterns for DeliveryRadiusCalculator/Nominatim geocoding, the skip_advance_notice parameter, and the SIMPLETEST_* environment requirements."
+applyTo: "web/modules/custom/store_fulfillment/tests/**"
+---
+
+# Store Fulfillment Test Conventions
+
+## How to Run
+
+```bash
+ddev phpunit
+```
+
+`phpunit.xml` at project root points the `store_fulfillment` suite to
+`web/modules/custom/store_fulfillment/tests/`. The required env vars are
+baked in — never set them manually on your machine.
+
+| Env var | Value |
+|---|---|
+| `SIMPLETEST_BASE_URL` | `https://duccinisv3.ddev.site` |
+| `SIMPLETEST_DB` | `mysql://db:db@db/db` |
+| `SYMFONY_DEPRECATIONS_HELPER` | `disabled` |
+
+Both Kernel and Functional tests **must** run inside DDEV (not bare PHP) because
+the DB connection string refers to the `db` Docker hostname.
+
+---
+
+## Kernel vs Functional — How to Choose
+
+| Question | Answer → Use |
+|---|---|
+| Testing a service method (validator, calculator)? | `Kernel` |
+| Testing event subscriber logic in isolation? | `Kernel` |
+| Testing a checkout form, AJAX, rendered HTML? | `Functional` |
+| Need a real browser session / assertSession? | `Functional` |
+
+### Kernel base class
+
+```php
+use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
+
+class MyServiceTest extends CommerceKernelTestBase {
+```
+
+`CommerceKernelTestBase` bootstraps Commerce entity schemas. You still **must**
+call `installEntitySchema()` and `installConfig()` for every entity/config you
+need — nothing is auto-installed beyond what the base class declares.
+
+### Functional base class
+
+```php
+use Drupal\Tests\commerce\Functional\CommerceBrowserTestBase;
+
+class MyCheckoutTest extends CommerceBrowserTestBase {
+  protected $defaultTheme = 'stark'; // required — always set this
+```
+
+`CommerceBrowserTestBase` provides `$this->store` and `$this->adminUser` out of
+the box. Always set `$defaultTheme = 'stark'` to avoid pulling in the full
+custom theme (slow, fragile) for functional tests.
+
+---
+
+## Required `$modules` Lists
+
+### Kernel tests for delivery / order services
+
+```php
+protected static $modules = [
+  'profile',
+  'state_machine',
+  'entity_reference_revisions',
+  'geofield',
+  'geocoder',
+  'store_resolver',
+  'store_fulfillment',
+];
+```
+
+Add `'commerce_order'` and `'commerce_number_pattern'` when creating `Order`
+entities. Add `'commerce_product'`, `'commerce_shipping'`, `'physical'` only
+when the test actually needs shipments — they pull in extra schemas.
+
+### Functional tests
+
+```php
+protected static $modules = [
+  'commerce_cart',
+  'commerce_checkout',
+  'commerce_payment',
+  'commerce_payment_example', // provides example_onsite gateway
+  'commerce_product',
+  'store_fulfillment',
+];
+```
+
+Add `'store_resolver'` when the checkout pane calls `store_resolver.current_store`.
+
+---
+
+## Installing Custom Fields in Kernel Tests
+
+`store_fulfillment_install()` creates the `delivery_radius` and `store_location`
+fields programmatically. In Kernel tests the install hook **does not run
+automatically** — call it explicitly after loading the include:
+
+```php
+protected function setUp(): void {
+  parent::setUp();
+  $this->installConfig(['store_fulfillment']);
+  \Drupal::moduleHandler()->loadInclude('store_fulfillment', 'install');
+  store_fulfillment_install();
+}
+```
+
+For `OrderValidatorTest` (which only needs `store_hours`), create just that
+field manually instead of calling the full install hook — it avoids pulling in
+the `geofield` dependency:
+
+```php
+$field_storage = \Drupal\field\Entity\FieldStorageConfig::loadByName('commerce_store', 'store_hours');
+if (!$field_storage) {
+  $field_storage = \Drupal\field\Entity\FieldStorageConfig::create([
+    'field_name' => 'store_hours',
+    'entity_type' => 'commerce_store',
+    'type' => 'string_long',
+    'cardinality' => -1,
+  ])->save();
+}
+```
+
+---
+
+## Mocking `DeliveryRadiusCalculator` and Nominatim Geocoding
+
+Never let tests call Nominatim. The geocoder makes HTTP requests — they will
+time out or return wrong data in CI.
+
+### Pattern 1 — mock `calculateDistance` only (fast, most common)
+
+```php
+$calculator = $this->getMockBuilder(DeliveryRadiusCalculator::class)
+  ->disableOriginalConstructor()
+  ->onlyMethods(['calculateDistance'])
+  ->getMock();
+$calculator->method('calculateDistance')->willReturn(5.0);
+```
+
+Then construct `DeliveryRadiusValidator` directly with the mock calculator:
+
+```php
+$this->validator = new DeliveryRadiusValidator(
+  $calculator,
+  $this->container->get('string_translation'),
+  $this->container->get('geocoder'),
+  $this->container->get('logger.factory'),
+  $this->container->get('entity_type.manager'),
+);
+```
+
+### Pattern 2 — mock `getStoreCoordinates` + `getAddressCoordinates` (control geocoding failure)
+
+When you need to test "store coords unavailable" or "address cannot be geocoded"
+code paths, mock those two protected methods on `DeliveryRadiusValidator` itself:
+
+```php
+protected function createValidatorWithMockedGeocoding(
+  bool $store_has_coords,
+  bool $address_has_coords,
+  float $distance
+): DeliveryRadiusValidator {
+  $calculator = $this->getMockBuilder(DeliveryRadiusCalculator::class)
+    ->disableOriginalConstructor()
+    ->onlyMethods(['calculateDistance'])
+    ->getMock();
+  $calculator->method('calculateDistance')->willReturn($distance);
+
+  $validator = $this->getMockBuilder(DeliveryRadiusValidator::class)
+    ->setConstructorArgs([
+      $calculator,
+      $this->container->get('string_translation'),
+      $this->container->get('geocoder'),
+      $this->container->get('logger.factory'),
+      $this->container->get('entity_type.manager'),
+    ])
+    ->onlyMethods(['getStoreCoordinates', 'getAddressCoordinates'])
+    ->getMock();
+
+  $validator->method('getStoreCoordinates')
+    ->willReturn($store_has_coords ? ['lat' => 37.7749, 'lon' => -122.4194] : NULL);
+  $validator->method('getAddressCoordinates')
+    ->willReturn($address_has_coords ? ['lat' => 37.7849, 'lon' => -122.4094] : NULL);
+
+  return $validator;
+}
+```
+
+### Pattern 3 — mock entire `DeliveryRadiusValidator` (event subscriber tests)
+
+For `OrderPlacementDeliveryRadiusValidatorTest`, mock the whole validator and
+stub `validateDeliveryAddress` to return a predetermined result array:
+
+```php
+protected function createMockValidator(bool $is_valid, float $distance): DeliveryRadiusValidator {
+  $validator = $this->getMockBuilder(DeliveryRadiusValidator::class)
+    ->disableOriginalConstructor()
+    ->getMock();
+
+  $validator->method('validateDeliveryAddress')->willReturn([
+    'valid'    => $is_valid,
+    'message'  => $is_valid ? 'Within service area.' : 'Outside service area.',
+    'distance' => $distance,
+  ]);
+
+  return $validator;
+}
+```
+
+---
+
+## Mocking `AddressInterface`
+
+Kernel tests cannot use real `profile` entities without accepting the full
+profile install overhead. Mock the interface instead:
+
+```php
+$address = $this->getMockBuilder(\Drupal\address\AddressInterface::class)->getMock();
+$address->method('getCountryCode')->willReturn('US');
+$address->method('getAdministrativeArea')->willReturn('DC');
+$address->method('getLocality')->willReturn('Washington');
+$address->method('getPostalCode')->willReturn('20009');
+$address->method('getAddressLine1')->willReturn('2415 18th St NW');
+```
+
+---
+
+## The `skip_advance_notice` Parameter
+
+`OrderValidator::validateFulfillmentTime()` accepts a third bool parameter:
+
+```php
+validateFulfillmentTime(OrderInterface $order, $requested_time, bool $skip_advance_notice = FALSE)
+```
+
+This exists because the advance-notice check must be **skipped at order placement
+time** (`commerce_order.place.pre_transition` event) — by the time the payment
+gateway round-trip completes, the scheduled time may be within the 30-minute
+window that was valid at checkout. Re-validating would block legitimate orders.
+
+- Checkout validation: `skip_advance_notice = FALSE` (default)
+- Placement event subscriber: `skip_advance_notice = TRUE`
+
+Test both paths explicitly when writing `OrderValidator` tests:
+
+```php
+// Checkout path — advance notice required.
+$result = $this->orderValidator->validateFulfillmentTime($order, $timestamp, FALSE);
+$this->assertFalse($result['valid']);
+
+// Placement path — advance notice skipped.
+$result = $this->orderValidator->validateFulfillmentTime($order, $timestamp, TRUE);
+$this->assertTrue($result['valid']);
+```
+
+---
+
+## Logger Mocking in Event Subscriber Tests
+
+Create a real `LoggerInterface` mock and wrap it in a `LoggerChannelFactoryInterface`
+mock rather than using a null logger — this lets you assert the correct log
+level was called:
+
+```php
+$this->logger = $this->getMockBuilder(\Psr\Log\LoggerInterface::class)->getMock();
+$this->loggerFactory = $this->getMockBuilder(\Drupal\Core\Logger\LoggerChannelFactoryInterface::class)->getMock();
+$this->loggerFactory->method('get')->willReturn($this->logger);
+
+// Assert correct log level.
+$this->logger->expects($this->once())
+  ->method('info')
+  ->with($this->stringContains('validated successfully'), $this->anything());
+```
+
+---
+
+## Creating a `WorkflowTransitionEvent` Mock
+
+Commerce's `pre_transition` events use `WorkflowTransitionEvent`. Mock it to
+return the test order:
+
+```php
+use Drupal\state_machine\Event\WorkflowTransitionEvent;
+
+protected function createMockWorkflowEvent(OrderInterface $order): WorkflowTransitionEvent {
+  $event = $this->getMockBuilder(WorkflowTransitionEvent::class)
+    ->disableOriginalConstructor()
+    ->getMock();
+  $event->method('getEntity')->willReturn($order);
+  return $event;
+}
+```
+
+---
+
+## Event Subscriber Priority — Test Registration
+
+Always include a test that verifies the event priority, not just that the event
+is subscribed:
+
+```php
+public function testEventSubscriberRegistration(): void {
+  $events = OrderPlacementDeliveryRadiusValidator::getSubscribedEvents();
+  $this->assertArrayHasKey('commerce_order.place.pre_transition', $events);
+  // Priority -100: after Commerce placement logic, before order is finalised.
+  $this->assertEquals(['onOrderPlace', -100], $events['commerce_order.place.pre_transition']);
+}
+```
+
+---
+
+## Shipment Fixture Setup (Kernel)
+
+When a test needs a real shipment on an order, configure the order type to allow
+shipments first, then use `commerce.configurable_field_manager` to create the
+field programmatically:
+
+```php
+$order_type = OrderType::load('default');
+$order_type->setThirdPartySetting('commerce_shipping', 'shipment_type', 'default');
+$order_type->save();
+
+$field_definition = commerce_shipping_build_shipment_field_definition($order_type->id());
+$this->container->get('commerce.configurable_field_manager')->createField($field_definition);
+```
+
+Then create the shipment entity normally:
+
+```php
+$profile = Profile::create([
+  'type' => 'customer',
+  'address' => ['country_code' => 'US', 'address_line1' => '456 Mission St', ...],
+]);
+$profile->save();
+
+$shipment = Shipment::create([
+  'type'             => 'default',
+  'order_id'         => $order->id(),
+  'title'            => 'Shipment',
+  'amount'           => new Price('5.00', 'USD'),
+  'shipping_profile' => $profile,
+]);
+$shipment->save();
+$order->set('shipments', [$shipment]);
+$order->save();
+```
+
+---
+
+## Test Grouping
+
+All tests must carry `@group store_fulfillment`. Functional tests that cover a
+specific issue may add a second group:
+
+```php
+/**
+ * @group store_fulfillment
+ * @group payment
+ */
+```
+
+---
+
+## Validation Result Shape Assertions
+
+Always assert the **full shape** of every validation result under test, not just
+the `valid` flag:
+
+```php
+$this->assertArrayHasKey('valid', $result);
+$this->assertArrayHasKey('message', $result);
+$this->assertArrayHasKey('distance', $result);
+$this->assertIsBool($result['valid']);
+$this->assertIsString($result['message']);
+// distance is float|null
+$this->assertTrue($result['distance'] === NULL || is_float($result['distance']));
+```

--- a/.github/instructions/store-fulfillment.instructions.md
+++ b/.github/instructions/store-fulfillment.instructions.md
@@ -1,0 +1,220 @@
+---
+description: "Use when writing or modifying code in store_fulfillment — Commerce checkout panes, shipping plugins, delivery radius validation, AJAX multi-pane patterns, event subscribers, and payment radios. Covers patterns that differ from standard Drupal/Commerce conventions."
+applyTo: "web/modules/custom/store_fulfillment/**"
+---
+
+# Store Fulfillment Module — Coding Patterns
+
+## Checkout Pane Service Injection
+
+Commerce checkout pane plugins extend `CheckoutPaneBase`. **Do not use constructor injection** — the parent constructor signature is fixed by the plugin system. Always use the `create()` factory pattern:
+
+```php
+public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, CheckoutFlowInterface $checkout_flow = NULL) {
+  $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition, $checkout_flow);
+  $instance->deliveryRadiusValidator = $container->get('store_fulfillment.delivery_radius_validator');
+  $instance->storeResolver           = $container->get('store_resolver.current_store');
+  return $instance;
+}
+```
+
+Standalone services (`OrderValidator`, `DeliveryRadiusValidator`, etc.) **do** use constructor injection normally.
+
+## Store Resolution — Always Use Fallback
+
+The cookie-based store resolver fails without a browser session (Drush, tests, CLI). Always fall back to the order's store:
+
+```php
+$store = $this->storeResolver->getCurrentStore() ?? $this->order->getStore();
+```
+
+## `isVisible()` — Conditionally Shown Panes Must Return TRUE
+
+Panes shown/hidden via AJAX must always return `TRUE` from `isVisible()`. Returning `FALSE` or making the pane inaccessible causes Commerce's `CheckoutFlowWithPanesBase::buildForm()` to call `Element::getVisibleChildren()` which removes the wrapper `<div>` from the DOM entirely, breaking AJAX targeting.
+
+Instead, control visibility inside `buildPaneForm()`:
+
+```php
+public function isVisible(): bool {
+  return TRUE; // Always in DOM for AJAX to work.
+}
+
+public function buildPaneForm(array $pane_form, FormStateInterface $form_state, array &$complete_form) {
+  $pane_form['#prefix'] = '<div id="delivery-address-wrapper" class="delivery-expand' . ($this->isDeliverySelected($form_state) ? ' open' : '') . '">';
+  $pane_form['#suffix'] = '</div>';
+
+  if (!$this->isDeliverySelected($form_state)) {
+    // Empty placeholder keeps the wrapper in the DOM.
+    $pane_form['placeholder'] = ['#markup' => ''];
+    return $pane_form;
+  }
+  // ... full form build
+}
+```
+
+## Delivery State Detection — Check Form State First
+
+Always check `$form_state` before `$order->getData()` so AJAX rebuilds reflect the current radio selection before it's persisted:
+
+```php
+protected function isDeliverySelected(?FormStateInterface $form_state = NULL): bool {
+  if ($form_state) {
+    $method = $form_state->getValue(['fulfillment_time', 'fulfillment_method']);
+    if (!$method) {
+      // Fallback for partial validation (e.g. #limit_validation_errors buttons).
+      $method = $form_state->getUserInput()['fulfillment_time']['fulfillment_method'] ?? NULL;
+    }
+    if ($method) {
+      return $method === 'delivery';
+    }
+  }
+  return $this->order->getData('fulfillment_method') === 'delivery';
+}
+```
+
+## AJAX — Multi-Pane Refresh Pattern
+
+When a single AJAX callback must update more than one section, return an explicit `AjaxResponse` with individual `ReplaceCommand` calls. Do **not** rely on Commerce's default AJAX (it only replaces the triggering pane's wrapper):
+
+```php
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+
+public function ajaxRefreshPane(array $form, FormStateInterface $form_state): AjaxResponse {
+  $response = new AjaxResponse();
+  $response->addCommand(new ReplaceCommand('#fulfillment-time-wrapper', $form['fulfillment_time']));
+  $response->addCommand(new ReplaceCommand('#delivery-address-wrapper', $form['delivery_address']));
+  $response->addCommand(new ReplaceCommand('#edit-payment-information', $form['payment_information']));
+  return $response;
+}
+```
+
+## validate/submit Guard for Hidden Panes
+
+When a pane may have rendered a placeholder (because delivery wasn't selected at build time), guard both `validatePaneForm` and `submitPaneForm` by checking the render array, **not** `isDeliverySelected()`:
+
+```php
+public function validatePaneForm(array &$pane_form, FormStateInterface $form_state, array &$complete_form) {
+  // Check render array first — form_state may disagree with build-time state.
+  if (!isset($pane_form['profile']['#inline_form'])) {
+    return;
+  }
+  if (!$this->isDeliverySelected($form_state)) {
+    return;
+  }
+  // ... validation logic
+}
+```
+
+## Order Data Storage
+
+Fulfillment state is stored as order data, not as field values:
+
+```php
+// Write
+$order->setData('fulfillment_method', 'delivery');   // 'pickup' | 'delivery'
+$order->setData('fulfillment_type', 'scheduled');    // 'asap' | 'scheduled'
+$order->setData('scheduled_time', '2026-02-25 18:30:00'); // Y-m-d H:i:s
+$order->setData('delivery_address_profile', $profile->id()); // int
+
+// Clear stale data when switching modes
+$order->unsetData('scheduled_time');
+
+// Read
+$method = $order->getData('fulfillment_method');
+```
+
+## Delivery Address Resolution Chain
+
+Both `FulfillmentTime::resolveCustomerAddress()` and `OrderPlacementDeliveryRadiusValidator::resolveDeliveryAddress()` must follow *the same* four-step fallback:
+
+1. `$order->getData('delivery_address_profile')` → load profile entity
+2. Shipping profile from `$order->get('shipments')` (first shipment)
+3. `$order->getBillingProfile()`
+4. Customer's default profile (`profile` storage, `uid`, `isDefault = 1`)
+
+Always keep these two methods in sync.
+
+## Validation Result Shape
+
+All validation methods return a consistent array — never a bare boolean:
+
+```php
+// DeliveryRadiusValidator::validateDeliveryAddress()
+return ['valid' => bool, 'message' => string, 'distance' => float|null];
+
+// OrderValidator::validateFulfillmentTime()
+return ['valid' => bool, 'message' => string];
+```
+
+Check `$result['valid']` before using `$result['message']`.
+
+## Event Subscribers — Order Placement
+
+Subscribe to `commerce_order.place.pre_transition`. Block placement by throwing `\InvalidArgumentException` (Commerce's state machine catches this and cancels the transition):
+
+```php
+public static function getSubscribedEvents(): array {
+  return [
+    'commerce_order.place.pre_transition' => ['onOrderPlace', -100],
+  ];
+}
+
+public function onOrderPlace(WorkflowTransitionEvent $event): void {
+  $order = $event->getEntity();
+  if ($order->getData('fulfillment_method') !== 'delivery') {
+    return;
+  }
+  // ... validate, then:
+  throw new \InvalidArgumentException($validation_result['message']);
+}
+```
+
+Priority `-100` ensures placement validators run **after** Commerce's own placement logic finishes.
+
+## `#after_build` vs `#process` on Radios
+
+**Never** add to `#process` on a pre-existing radios element. At `hook_form_alter` time, `#process` doesn't exist on the element, so `$element['#process'][] = ...` creates a brand-new array overwriting Drupal's defaults via `$element += $element_info`. This drops `Radios::processRadios()` and produces zero child radio elements.
+
+Instead, always use `#after_build`, which runs after all `#process` callbacks:
+
+```php
+// ✅ Correct
+$radios['#after_build'][] = 'store_fulfillment_payment_radios_after_build';
+
+// ❌ Never do this
+$radios['#process'][] = 'store_fulfillment_payment_radios_process';
+```
+
+## Logger Channel
+
+Always log to the `'store_fulfillment'` channel:
+
+```php
+$this->loggerFactory->get('store_fulfillment')->error('...');
+```
+
+## Config Keys
+
+Module settings live at `store_fulfillment.settings`:
+
+| Key | Default | Description |
+|---|---|---|
+| `minimum_advance_notice` | 30 | Minutes ahead required for scheduled orders |
+| `maximum_scheduling_window` | 14 | Max days ahead orders can be scheduled |
+| `time_slot_interval` | 15 | Minutes between available time slots |
+
+```php
+$config = $this->configFactory->get('store_fulfillment.settings');
+$min_advance = $config->get('minimum_advance_notice') ?? 30;
+```
+
+## Services Reference
+
+| ID | Class | Key Dependency |
+|---|---|---|
+| `store_fulfillment.delivery_radius_calculator` | `DeliveryRadiusCalculator` | `@geocoder` |
+| `store_fulfillment.delivery_radius_validator` | `DeliveryRadiusValidator` | `@store_fulfillment.delivery_radius_calculator` |
+| `store_fulfillment.order_validator` | `OrderValidator` | `@store_resolver.hours_validator` |
+| `store_fulfillment.order_placement_validator` | `OrderPlacementValidator` | event_subscriber tag |
+| `store_fulfillment.order_placement_delivery_radius_validator` | `OrderPlacementDeliveryRadiusValidator` | event_subscriber tag |

--- a/.github/instructions/theme-duccinis-1984-olympics.instructions.md
+++ b/.github/instructions/theme-duccinis-1984-olympics.instructions.md
@@ -1,0 +1,284 @@
+---
+description: "Use when writing or modifying files in the duccinis_1984_olympics theme — Twig templates, SCSS, SDC components, JS behaviors, preprocess functions, and library definitions. Covers the build pipeline, the #after_build ↔ Twig variable chain for saved-card display, and the CSS-only :checked selection state pattern."
+applyTo: "web/themes/custom/duccinis_1984_olympics/**"
+---
+
+# duccinis_1984_olympics Theme — Coding Patterns
+
+## Build Pipeline
+
+The theme uses **Laravel Mix (webpack.mix.js)** with Sass. **Never edit files
+in `build/` directly** — they are generated output.
+
+```bash
+# Compile once (inside DDEV — corepack is enabled there)
+ddev npm run dev
+
+# Watch mode
+ddev npm run watch
+```
+
+After editing any `.scss` or component `.js` file, run `ddev npm run dev` and
+**also run `ddev drush cr`** — Drupal caches the SDC asset manifest and library
+definitions. Without a cache clear the old compiled CSS is served.
+
+### What compiles what
+
+| Source | Output |
+|---|---|
+| `src/scss/main.style.scss` | `build/css/main.style.css` |
+| `src/js/main.script.js` | `build/js/main.script.js` |
+| `components/**/*.scss` | `components/**/*.css` (same path, `.css` extension) |
+| `components/**/_*.js` (underscore-prefixed) | `components/**/*.js` (underscore stripped) |
+
+SDC component CSS is compiled from `components/<name>/<name>.scss` to
+`components/<name>/<name>.css` by the glob loop in `webpack.mix.js`. The `.css`
+file is what Drupal reads from the SDC manifest — never import component SCSS
+from `main.style.scss`.
+
+---
+
+## Library Definitions (`duccinis_1984_olympics.libraries.yml`)
+
+When adding a new JS file, define a library entry before attaching it:
+
+```yaml
+my-feature:
+  js:
+    src/js/my-feature.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings   # only if you read drupalSettings in JS
+    - core/jquery           # only if you use $()
+    - core/once             # required when using once()
+```
+
+Attach from PHP:
+
+```php
+// From hook_form_alter or a preprocess:
+$form['#attached']['library'][] = 'duccinis_1984_olympics/my-feature';
+
+// SDC component CSS is loaded via the SDC library name, NOT libraries.yml:
+$form['#attached']['library'][] = 'core/components.duccinis_1984_olympics--saved-card';
+```
+
+---
+
+## `includes/` PHP Preprocess Files
+
+Preprocess functions live in `includes/*.theme` files (loaded automatically by
+`duccinis_1984_olympics.theme`). Keep one file per Drupal hook family — e.g.,
+`form.theme` for all form-related preprocesses.
+
+Do **not** add preprocess logic directly to `duccinis_1984_olympics.theme`.
+
+---
+
+## The `#after_build` → Preprocess → Twig Variable Chain
+
+The saved-card display requires three cooperating pieces. Understand this
+chain before modifying any part of it.
+
+### Step 1 — `store_fulfillment_payment_radios_after_build()` (PHP, module)
+
+Runs after `Radios::processRadios()` has created individual `<input>` children.
+Stamps metadata onto each child element:
+
+```php
+// For stored payment method radios (numeric option_id):
+$element[$opt_id]['#card_data'] = [
+  'brand'    => 'visa',
+  'last4'    => '4242',
+  'expMonth' => '03',
+  'expYear'  => '2033',
+];
+$element[$opt_id]['#attributes']['class'][] = 'saved-card__radio';
+$element[$opt_id]['#attributes']['class'][] = 'visually-hidden';
+
+// For the gateway "Use a different card" option (non-numeric option_id):
+$element[$opt_id]['#is_new_card_option'] = TRUE;
+$element[$opt_id]['#attributes']['class'][] = 'saved-card__radio';
+$element[$opt_id]['#attributes']['class'][] = 'visually-hidden';
+```
+
+### Step 2 — `duccinis_1984_olympics_preprocess_form_element()` (PHP, `includes/form.theme`)
+
+Reads the stamped properties and promotes them to top-level Twig variables:
+
+```php
+function duccinis_1984_olympics_preprocess_form_element(array &$variables): void {
+  $element = $variables['element'];
+
+  if (!empty($element['#card_data'])) {
+    $variables['card_data']   = $element['#card_data'];
+    $variables['element_id']  = $element['#id'] ?? NULL;
+  }
+  elseif (!empty($element['#is_new_card_option'])) {
+    $variables['is_new_card'] = TRUE;
+    $variables['element_id']  = $element['#id'] ?? NULL;
+  }
+}
+```
+
+`element_id` is the `id` attribute of the hidden `<input>` — it is used in the
+Twig template as `for="{{ element_id }}"` on the `<label>` to link them.
+
+### Step 3 — `templates/form/form-element--radio.html.twig`
+
+Renders three distinct layouts based on which variables are defined:
+
+```twig
+{% if card_data is defined %}
+  {# Saved card row — brand badge, masked number, expiry #}
+  <div class="saved-card-item">
+    {{ children }}  {# <-- the visually-hidden <input type="radio"> #}
+    <label for="{{ element_id }}" class="saved-card"> … </label>
+  </div>
+
+{% elseif is_new_card is defined %}
+  {# "+ Use a different card" row #}
+  <div class="saved-card-item saved-card-item--new">
+    {{ children }}
+    <label for="{{ element_id }}" class="saved-card__new-link"> … </label>
+  </div>
+
+{% else %}
+  {# All other radios — fall through to Radix component #}
+  {% include 'radix:form-element--radiocheckbox' … %}
+{% endif %}
+```
+
+**Critical constraint:** `{{ children }}` renders the `<input type="radio">`.
+It **must come before** the `<label>` in the DOM. The entire selection state
+is driven by the CSS adjacent-sibling selector:
+
+```scss
+.saved-card__radio:checked + .saved-card { … }
+```
+
+If you reorder `{{ children }}` after the `<label>`, the `:checked` CSS rule
+stops working and the selected state disappears with no JS error to debug.
+
+---
+
+## CSS-Only `:checked` Selection State — Rules
+
+The saved-card selected state uses **no JavaScript**. These CSS patterns make
+it work:
+
+```scss
+// Correct: radio immediately precedes the label (.saved-card or .saved-card__new-link).
+.saved-card__radio:checked + .saved-card {
+  border-color: $olympics-blue;
+  background: lighten($olympics-blue, 48%);
+
+  .saved-card__check {
+    opacity: 1;
+  }
+}
+
+// Correct: new-card link active state.
+.saved-card__radio:checked + .saved-card__new-link {
+  color: $olympics-magenta;
+  font-weight: 600;
+}
+```
+
+**Rules to preserve this pattern:**
+
+1. Never insert any element between `{{ children }}` and `<label>` in the Twig template.
+2. `visually-hidden` (not `display:none` or `visibility:hidden`) must be used on `<input>` — the element must be focusable and occupy layout space for the adjacent-sibling selector to work in all browsers.
+3. Do not add a wrapper `<div>` between the `<input>` and `<label>`.
+
+---
+
+## `saved-card-fix.js` — When to Modify
+
+`saved-card-fix.js` (library `duccinis_1984_olympics/saved-card-fix`) handles
+one specific edge case: when the Stripe gateway radio is **already checked** and
+the user clicks the "+ Use a different card" label, no native `change` event
+fires (nothing changed), so Drupal's AJAX handler never runs.
+
+The behavior uses `once()` to avoid double-attaching:
+
+```js
+Drupal.behaviors.savedCardNewCardLink = {
+  attach(context) {
+    once('saved-card-new-link', '.saved-card-item--new label', context).forEach(
+      function (label) {
+        label.addEventListener('click', function () {
+          const radio = document.getElementById(label.getAttribute('for'));
+          if (radio && radio.checked) {
+            $(radio).trigger('change'); // force jQuery change for Drupal AJAX
+          }
+        });
+      },
+    );
+  },
+};
+```
+
+This file is attached from `store_fulfillment_form_alter()` — it is **not**
+auto-loaded. Do not move this responsibility to a Twig template or a global
+library attachment.
+
+### `drupalSettings` dependency
+
+`saved-card-fix.js` lists `core/drupalSettings` as a dependency in
+`libraries.yml`. This is required — removing it changes JS asset load order and
+may cause the behavior to attach before Drupal AJAX bindings are registered.
+
+---
+
+## SDC Component Conventions (`components/`)
+
+Each SDC lives in `components/<name>/` and requires:
+
+| File | Purpose |
+|---|---|
+| `<name>.component.yml` | Schema definition (props, slots) |
+| `<name>.twig` | Component template |
+| `<name>.scss` | Component styles (compiled to `<name>.css`) |
+
+The `$schema` key in `.component.yml` must point to the SDC metadata schema:
+
+```yaml
+$schema: https://git.drupalcode.org/project/sdc/-/raw/1.x/src/metadata.schema.json
+name: My Component
+status: experimental
+```
+
+To load a component's compiled CSS from a form alter or preprocess:
+
+```php
+$form['#attached']['library'][] = 'core/components.duccinis_1984_olympics--saved-card';
+// Pattern: core/components.<theme_name>--<component-name>
+```
+
+After creating or renaming a component, run `ddev drush cr` to regenerate the
+SDC discovery cache.
+
+---
+
+## Overriding Drupal Core/contrib Libraries
+
+The theme overrides several core libraries (e.g., `drupal.ajax`, `drupal.dialog`)
+by declaring library entries in `libraries.yml` that use the **same machine names**
+as the core libraries. These overrides live in `src/js/overrides/`.
+
+When editing an override file, test that the original Drupal behavior still
+works — these files completely replace the corresponding core JS.
+
+---
+
+## Cache Clearing Requirements
+
+| Change | Required commands |
+|---|---|
+| Any `.twig` template edit | `ddev drush cr` |
+| New or renamed preprocess function | `ddev drush cr` |
+| New `*.libraries.yml` entry | `ddev drush cr` |
+| New SDC component or `.component.yml` change | `ddev drush cr` |
+| `.scss` / `.js` source change | `ddev npm run dev` then `ddev drush cr` |
+| `#attached['library']` added in PHP | `ddev drush cr` |

--- a/.github/prompts/add-checkout-pane.prompt.md
+++ b/.github/prompts/add-checkout-pane.prompt.md
@@ -1,0 +1,94 @@
+---
+description: "Scaffold a new Commerce CheckoutPaneBase plugin for store_fulfillment — generates the plugin class, services.yml entry, and a Kernel test stub."
+name: "Add Checkout Pane"
+argument-hint: "Pane name (e.g. LoyaltyPoints), plugin ID (e.g. loyalty_points), brief purpose"
+agent: "agent"
+---
+
+Scaffold a new Commerce `CheckoutPaneBase` plugin for the `store_fulfillment` module.
+
+Follow the patterns in [.github/instructions/store-fulfillment.instructions.md](../instructions/store-fulfillment.instructions.md) and [.github/instructions/store-fulfillment-tests.instructions.md](../instructions/store-fulfillment-tests.instructions.md) exactly.
+
+## Inputs
+
+The user will provide (ask if any are missing):
+
+- **Class name** — PascalCase, e.g. `LoyaltyPoints`
+- **Plugin ID** — snake_case, e.g. `loyalty_points`
+- **Purpose** — one sentence describing what this pane does
+- **Is conditionally shown/hidden via AJAX?** — yes/no (default: no)
+- **Services needed** — list any `store_fulfillment.*` or other Drupal services this pane needs
+
+## What to generate
+
+### 1. Plugin class
+
+File: `web/modules/custom/store_fulfillment/src/Plugin/Commerce/CheckoutPane/{ClassName}.php`
+
+Requirements:
+- `declare(strict_types=1);` at top
+- Annotation: `@CommerceCheckoutPane(id = "{plugin_id}", label = @Translation("…"), default_step = "order_information", wrapper_element = "container")`
+- Extend `CheckoutPaneBase`, implement `CheckoutPaneInterface`
+- **Use `create()` factory pattern** — never add services to the constructor
+- `isVisible()`: return `TRUE` always (even if conditionally shown — visibility is controlled in `buildPaneForm`)
+- If conditionally shown/hidden via AJAX:
+  - `buildPaneForm()` must wrap output in `#prefix`/`#suffix` with a named `id="..."` wrapper div
+  - When content should be hidden, render `$pane_form['placeholder'] = ['#markup' => ''];` and return early — never use `#access = FALSE` or return `[]`
+- `validatePaneForm()`: guard with `if (!isset($pane_form['some_key'])) { return; }` before any logic
+- `submitPaneForm()`: same guard pattern; store state via `$this->order->setData()`
+
+### 2. Register services (if new services are needed)
+
+Add to `web/modules/custom/store_fulfillment/store_fulfillment.services.yml` only if the pane introduces a new service class. Panes themselves are plugins — they do not need service entries. Only standalone service classes need entries.
+
+### 3. Config export reminder
+
+After implementation, remind the user to register the pane in the checkout flow config and export:
+
+```
+ddev drush cex
+```
+
+The checkout flow config lives at:
+`config/sync/commerce_checkout.commerce_checkout_flow.default.yml`
+
+### 4. Kernel test stub
+
+File: `web/modules/custom/store_fulfillment/tests/src/Kernel/{ClassName}Test.php`
+
+Requirements:
+- Extend `CommerceKernelTestBase`
+- `@group store_fulfillment`
+- `protected static $modules` — include the minimum set (see test instructions)
+- `setUp()`: call `$this->installConfig(['store_fulfillment'])`, load the install include and call `store_fulfillment_install()` if the pane touches `delivery_radius` or `store_location` fields
+- At least three test methods:
+  1. Test that `buildPaneForm()` returns the expected element keys when active
+  2. Test that `validatePaneForm()` skips gracefully when the pane rendered a placeholder (guard path)
+  3. Test the `submitPaneForm()` data storage (assert `$order->getData(...)` after submit)
+- Mock any geocoding or external services — never make real HTTP calls
+
+### 5. Functional test stub
+
+File: `web/modules/custom/store_fulfillment/tests/src/Functional/{ClassName}CheckoutTest.php`
+
+Requirements:
+- Extend `CommerceBrowserTestBase`
+- `protected $defaultTheme = 'stark';` — always set this
+- `@group store_fulfillment`
+- `protected static $modules` — include `commerce_cart`, `commerce_checkout`, `commerce_product`, `store_fulfillment`, plus `store_resolver` if the pane calls `store_resolver.current_store`
+- `setUp()`: create a minimal product variation + product attached to `$this->store` so checkout is accessible
+- At least three test methods:
+  1. Test that the pane renders on `GET /checkout/{order_id}/order_information` — assert HTTP 200 and a key element or text string that uniquely identifies this pane
+  2. If conditionally shown/hidden via AJAX: test that the AJAX wrapper div (`#<plugin_id>-wrapper`) is present in the initial DOM even when hidden; test that toggling the trigger selector shows/hides the pane content
+  3. Test a full form submit path — fill the pane fields, submit, reload the order entity, and assert `$order->getData('{plugin_id}_*')` was persisted correctly
+
+## Output format
+
+Generate the files one at a time in this order:
+1. Plugin PHP class
+2. Kernel test class
+3. Functional test class
+4. Any services.yml additions (diff-style, show only the new block)
+5. A short checklist of manual steps (config registration, cache clear, test run command)
+
+Do not generate markdown documentation files.


### PR DESCRIPTION
Rewrote copilot-instructions.md -- replaced generic placeholder template with full project content: DDEV commands, 3-store architecture, module and service registry, checkout flow pane weights, Stripe offsite flow, order data storage patterns, AJAX ReplaceCommand pattern, pre-commit gates.

Added store-fulfillment.instructions.md (applyTo: store_fulfillment/**) Covers: create() factory pattern, isVisible()=TRUE, AJAX multi-pane ReplaceCommand, validate/submit render-array guards, #after_build vs #process, 4-step address resolution chain, event subscriber priority.

Added store-fulfillment-tests.instructions.md (applyTo: tests/**) Covers: DDEV-only run requirement, Kernel vs Functional base class selection, field install hook pattern, three geocoding mock strategies, skip_advance_notice dual-path testing, WorkflowTransitionEvent mock.

Added theme-duccinis-1984-olympics.instructions.md (applyTo: theme/**) Covers: ddev npm run dev + drush cr build sequence, SDC compilation paths, #after_build -> preprocess -> Twig variable chain, CSS-only :checked selection state, children-before-label DOM order constraint.

Added add-checkout-pane.prompt.md (/add-checkout-pane slash command) Scaffolds CheckoutPaneBase plugin with Kernel and Functional test stubs.

Updated themer.agent.md v1 -> v2 -- replaced Friday Night Skate boilerplate (wrong theme name, ddev yarn build, Masonry/Swiper) with duccinis_1984_olympics-specific content; links to new theme instruction.