### PR TITLE
test(store_fulfillment): add #after_build regression tests for issue …

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="512M"/>
-    <env name="SIMPLETEST_BASE_URL" value="https://duccinisv3.ddev.site"/>
+    <env name="SIMPLETEST_BASE_URL" value="https://duccinisv4.ddev.site"/>
     <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/browser_output"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>

--- a/web/modules/custom/store_fulfillment/store_fulfillment.module
+++ b/web/modules/custom/store_fulfillment/store_fulfillment.module
@@ -117,8 +117,13 @@ function store_fulfillment_form_alter(array &$form, FormStateInterface $form_sta
     // in zero child radio elements being created.
     $radios['#saved_card_data'] = $cards;
     $radios['#after_build'][] = 'store_fulfillment_payment_radios_after_build';
-    $form['payment_information']['#attached']['library'][] = 'core/components.duccinis_1984_olympics--saved-card';
-    $form['payment_information']['#attached']['library'][] = 'duccinis_1984_olympics/saved-card-fix';
+    // Only attach theme-specific libraries when the custom theme is active.
+    // Skipped during testing (stark theme) and on any other theme, which
+    // prevents UnknownExtensionException when the theme is not installed.
+    if (\Drupal::service('theme_handler')->themeExists('duccinis_1984_olympics')) {
+      $form['payment_information']['#attached']['library'][] = 'core/components.duccinis_1984_olympics--saved-card';
+      $form['payment_information']['#attached']['library'][] = 'duccinis_1984_olympics/saved-card-fix';
+    }
   }
 }
 

--- a/web/modules/custom/store_fulfillment/tests/src/Functional/PaymentPaneFormAlterTest.php
+++ b/web/modules/custom/store_fulfillment/tests/src/Functional/PaymentPaneFormAlterTest.php
@@ -150,6 +150,141 @@ class PaymentPaneFormAlterTest extends CommerceBrowserTestBase {
     );
   }
 
+  // ─── Issue #106: #after_build regression tests ──────────────────────────
+
+  /**
+   * Tests that saved-card radio inputs exist in the DOM when the user has a stored payment method.
+   *
+   * This is the primary regression test for issue #106.  The original bug: the
+   * module used #process instead of #after_build.  Using #process overwrote
+   * Drupal's default #process array (including Radios::processRadios()) and
+   * produced ZERO child radio elements — the radio list appeared empty.  The
+   * fix registers our callback via #after_build so Radios::processRadios()
+   * always runs first.
+   *
+   * If this test fails with "zero radio inputs found", the #after_build →
+   * #process regression has been reintroduced.
+   */
+  public function testSavedCardRadioInputsExistInDom(): void {
+    $this->createSavedPaymentMethodForAdminUser();
+    $order = $this->createOrder();
+    $this->drupalGet('/checkout/' . $order->id() . '/order_information');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $radios = $this->getSession()->getPage()->findAll(
+      'css',
+      '#edit-payment-information input[type="radio"]',
+    );
+    $this->assertNotEmpty(
+      $radios,
+      'At least one radio input must be rendered inside #edit-payment-information. '
+      . 'Zero radios means Radios::processRadios() did not run — a sign that #process '
+      . 'was used instead of #after_build (issue #106 regression).',
+    );
+  }
+
+  /**
+   * Tests that the payment_information wrapper receives the has-saved-cards class when the user has a stored payment method.
+   *
+   * This class is added by store_fulfillment_form_alter() when the saved-card
+   * detection loop finds at least one eligible payment method.  Its presence
+   * proves the loop ran and that #after_build was registered.
+   */
+  public function testPaymentPaneHasSavedCardsClassWhenSavedMethodExists(): void {
+    $this->createSavedPaymentMethodForAdminUser();
+    $order = $this->createOrder();
+    $this->drupalGet('/checkout/' . $order->id() . '/order_information');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->elementExists(
+      'css',
+      '#edit-payment-information.has-saved-cards',
+    );
+  }
+
+  /**
+   * Tests that saved-card radio inputs carry the visually-hidden CSS class.
+   *
+   * The #after_build callback adds this class to hide the native
+   * input[type="radio"] so the styled SDC label row is the visual affordance.
+   * Its presence confirms the callback ran after Radios::processRadios().
+   */
+  public function testSavedCardRadioInputsHaveVisuallyHiddenClass(): void {
+    $this->createSavedPaymentMethodForAdminUser();
+    $order = $this->createOrder();
+    $this->drupalGet('/checkout/' . $order->id() . '/order_information');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->elementExists(
+      'css',
+      '#edit-payment-information input[type="radio"].visually-hidden',
+    );
+  }
+
+  /**
+   * Tests the payment pane lacks has-saved-cards class with no stored methods.
+   *
+   * Control case: without saved methods the #after_build callback is never
+   * registered, so the class must not appear.
+   */
+  public function testPaymentPaneLacksSavedCardsClassWithNoSavedMethods(): void {
+    // No saved payment method created.
+    $order = $this->createOrder();
+    $this->drupalGet('/checkout/' . $order->id() . '/order_information');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->elementNotExists(
+      'css',
+      '#edit-payment-information.has-saved-cards',
+    );
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a reusable credit-card payment method owned by the admin user.
+   *
+   * Uses the 'example' gateway (example_onsite plugin) from setUp().  The
+   * card_type field triggers the Commerce-core branch in store_fulfillment
+   * form_alter so that #saved_card_data is populated and #after_build is
+   * registered on the radios element.
+   *
+   * A billing profile with a US address is required because the test store has
+   * billing_countries = ['US'] and Commerce's loadReusable() filters out any
+   * payment method whose billing profile country does not match.
+   */
+  protected function createSavedPaymentMethodForAdminUser(): void {
+    // Create a billing profile with a US address to satisfy the store's
+    // billing_countries filter in PaymentMethodStorage::loadReusable().
+    $billing_profile = $this->createEntity('profile', [
+      'type' => 'customer',
+      'uid' => $this->adminUser->id(),
+      'address' => [
+        'country_code' => 'US',
+        'administrative_area' => 'DC',
+        'locality' => 'Washington',
+        'postal_code' => '20009',
+        'address_line1' => '1800 Adams Mill Rd NW',
+        'given_name' => 'Test',
+        'family_name' => 'User',
+      ],
+    ]);
+
+    $payment_method = $this->createEntity('commerce_payment_method', [
+      'type' => 'credit_card',
+      'uid' => $this->adminUser->id(),
+      'payment_gateway' => 'example',
+      'card_type' => 'visa',
+      'card_number' => '1111',
+      'billing_profile' => $billing_profile,
+      'remote_id' => 789,
+      'reusable' => TRUE,
+      'expires' => strtotime('+5 years'),
+    ]);
+    $payment_method->setBillingProfile($billing_profile);
+    $payment_method->save();
+  }
+
   /**
    * Creates a minimal draft order with one item for checkout testing.
    *

--- a/web/modules/custom/store_fulfillment/tests/src/Kernel/PaymentRadiosAfterBuildTest.php
+++ b/web/modules/custom/store_fulfillment/tests/src/Kernel/PaymentRadiosAfterBuildTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\store_fulfillment\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
+
+/**
+ * Unit-style tests for store_fulfillment_payment_radios_after_build().
+ *
+ * Issue #106: the original bug was that #process was used instead of
+ * #after_build, which overwrote Drupal's default #process array (including
+ * Radios::processRadios()) and produced zero child radio elements.
+ *
+ * These tests call the global callback function directly with synthetic element
+ * arrays so they run fast without Commerce entity overhead.
+ *
+ * @group store_fulfillment
+ * @group payment
+ */
+class PaymentRadiosAfterBuildTest extends CommerceKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'profile',
+    'state_machine',
+    'entity_reference_revisions',
+    'geofield',
+    'geocoder',
+    'store_resolver',
+    'store_fulfillment',
+  ];
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Builds a minimal radios element mimicking what Radios::processRadios() produces.
+   *
+   * Creates a parent element with keyed child elements for each option.
+   *
+   * @param array $saved_cards
+   *   The value to set as $element['#saved_card_data'].
+   * @param array $options
+   *   The #options array (same keys used to create child elements).
+   *
+   * @return array
+   *   A synthetic radios element ready to pass to the after_build callback.
+   */
+  private function buildElement(array $saved_cards, array $options): array {
+    $element = [
+      '#type' => 'radios',
+      '#options' => $options,
+      '#saved_card_data' => $saved_cards,
+    ];
+    // Mimic the per-option children Radios::processRadios() would create.
+    foreach (array_keys($options) as $key) {
+      $element[$key] = [
+        '#type' => 'radio',
+        '#attributes' => ['class' => []],
+      ];
+    }
+    return $element;
+  }
+
+  // ─── Callback behaviour ───────────────────────────────────────────────────
+
+  /**
+   * Tests that #card_data is stamped onto a numeric child element.
+   */
+  public function testCallbackStampsCardDataOnNumericChild(): void {
+    $card = ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030'];
+    $element = $this->buildElement(
+      ['1' => $card],
+      ['1' => 'Visa ending in 4242'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertSame(
+      $card,
+      $result['1']['#card_data'],
+      '#card_data must be set on the child radio element matching the saved-card ID.',
+    );
+  }
+
+  /**
+   * Tests that the visually-hidden class is added to saved-card radio inputs.
+   */
+  public function testCallbackAddsVisuallyHiddenClassToSavedCardRadio(): void {
+    $element = $this->buildElement(
+      ['2' => ['brand' => 'mastercard', 'last4' => '0000', 'expMonth' => '01', 'expYear' => '2029']],
+      ['2' => 'Mastercard ending in 0000'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertContains(
+      'visually-hidden',
+      $result['2']['#attributes']['class'],
+      'visually-hidden CSS class must be added to the saved-card radio input.',
+    );
+  }
+
+  /**
+   * Tests that the saved-card__radio class is added to saved-card radio inputs.
+   */
+  public function testCallbackAddsSavedCardRadioClass(): void {
+    $element = $this->buildElement(
+      ['3' => ['brand' => 'amex', 'last4' => '1234', 'expMonth' => '06', 'expYear' => '2028']],
+      ['3' => 'Amex ending in 1234'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertContains(
+      'saved-card__radio',
+      $result['3']['#attributes']['class'],
+      'saved-card__radio CSS class must be added to the saved-card radio input.',
+    );
+  }
+
+  /**
+   * Tests that a non-numeric option key is marked as the "add new card" option.
+   *
+   * Commerce uses the string key 'add_new' (or the payment gateway ID) for the
+   * "Use a different card" option.  The callback must detect non-numeric keys
+   * and stamp #is_new_card_option = TRUE plus the two CSS classes.
+   */
+  public function testCallbackMarksNonNumericOptionAsNewCard(): void {
+    $element = $this->buildElement(
+      [],
+      ['add_new' => '+ Use a different card'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertTrue(
+      $result['add_new']['#is_new_card_option'],
+      '#is_new_card_option must be TRUE for non-numeric option keys.',
+    );
+    $this->assertContains('visually-hidden', $result['add_new']['#attributes']['class']);
+    $this->assertContains('saved-card__radio', $result['add_new']['#attributes']['class']);
+  }
+
+  /**
+   * Tests that numeric option keys are NOT marked as new-card options.
+   */
+  public function testCallbackDoesNotMarkNumericOptionAsNewCard(): void {
+    $element = $this->buildElement(
+      ['1' => ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030']],
+      ['1' => 'Visa ending in 4242'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertArrayNotHasKey(
+      '#is_new_card_option',
+      $result['1'],
+      'Numeric option keys must never receive #is_new_card_option.',
+    );
+  }
+
+  /**
+   * Tests mixed options: saved cards + "add new" — both processed correctly.
+   *
+   * This is the real-world scenario: Commerce renders numeric saved payment
+   * method IDs alongside the gateway ID as the "add new" string key.
+   */
+  public function testCallbackProcessesMixedOptions(): void {
+    $card = ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030'];
+    $element = $this->buildElement(
+      ['5' => $card],
+      ['5' => 'Visa ending in 4242', 'example' => '+ Use a different card'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    // Saved card child gets card data + classes.
+    $this->assertSame($card, $result['5']['#card_data']);
+    $this->assertContains('visually-hidden', $result['5']['#attributes']['class']);
+    $this->assertContains('saved-card__radio', $result['5']['#attributes']['class']);
+
+    // "Add new" child gets is_new_card_option + classes.
+    $this->assertTrue($result['example']['#is_new_card_option']);
+    $this->assertContains('visually-hidden', $result['example']['#attributes']['class']);
+    $this->assertContains('saved-card__radio', $result['example']['#attributes']['class']);
+
+    // "Add new" child must NOT have card data.
+    $this->assertArrayNotHasKey('#card_data', $result['example']);
+  }
+
+  /**
+   * Tests multiple saved cards — all children stamped correctly.
+   */
+  public function testCallbackHandlesMultipleSavedCards(): void {
+    $card1 = ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030'];
+    $card2 = ['brand' => 'mastercard', 'last4' => '0000', 'expMonth' => '03', 'expYear' => '2027'];
+    $element = $this->buildElement(
+      ['10' => $card1, '11' => $card2],
+      ['10' => 'Visa', '11' => 'Mastercard', 'example' => '+ Use a different card'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertSame($card1, $result['10']['#card_data']);
+    $this->assertSame($card2, $result['11']['#card_data']);
+    $this->assertContains('visually-hidden', $result['10']['#attributes']['class']);
+    $this->assertContains('visually-hidden', $result['11']['#attributes']['class']);
+  }
+
+  /**
+   * Tests that empty #saved_card_data leaves child elements untouched.
+   */
+  public function testCallbackLeavesChildrenIntactWhenNoSavedCards(): void {
+    $element = $this->buildElement(
+      [],
+      ['1' => 'Visa ending in 4242'],
+    );
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertArrayNotHasKey('#card_data', $result['1'], 'Child must not gain #card_data when saved_card_data is empty.');
+    $this->assertEmpty($result['1']['#attributes']['class'], 'No CSS classes should be added when saved_card_data is empty.');
+  }
+
+  /**
+   * Tests that missing #saved_card_data key does not cause a PHP error.
+   */
+  public function testCallbackHandlesMissingSavedCardDataKey(): void {
+    // Deliberately omit '#saved_card_data' — simulates an older form_alter
+    // that did not set the key (defensive: callback must be resilient).
+    $element = [
+      '#type' => 'radios',
+      '#options' => ['1' => 'Visa'],
+      '1' => ['#type' => 'radio', '#attributes' => ['class' => []]],
+    ];
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertIsArray($result, 'Callback must return an array even when #saved_card_data is absent.');
+    $this->assertArrayNotHasKey('#card_data', $result['1']);
+  }
+
+  /**
+   * Tests that #saved_card_data IDs with no matching child element are ignored.
+   *
+   * Simulates a race-condition where a saved payment method is in
+   * #saved_card_data but was not turned into a radio child (e.g., filtered
+   * out by Commerce before the after_build runs).
+   */
+  public function testCallbackIgnoresSavedCardDataWithNoMatchingChild(): void {
+    $element = [
+      '#type' => 'radios',
+      '#options' => ['1' => 'Visa'],
+      '#saved_card_data' => [
+        // ID 99 exists in saved_card_data but NOT as a child element.
+        '99' => ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030'],
+      ],
+      '1' => ['#type' => 'radio', '#attributes' => ['class' => []]],
+    ];
+
+    // Must not PHP-error; child '1' is unaffected.
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertArrayNotHasKey('#card_data', $result['1']);
+    $this->assertEmpty($result['1']['#attributes']['class']);
+  }
+
+  /**
+   * Tests that the callback preserves pre-existing CSS classes on children.
+   *
+   * Other modules or preprocess hooks may add classes before after_build runs.
+   * The callback must append (not replace) the CSS class array.
+   */
+  public function testCallbackPreservesExistingCssClasses(): void {
+    $element = [
+      '#type' => 'radios',
+      '#options' => ['1' => 'Visa'],
+      '#saved_card_data' => [
+        '1' => ['brand' => 'visa', 'last4' => '4242', 'expMonth' => '12', 'expYear' => '2030'],
+      ],
+      '1' => [
+        '#type' => 'radio',
+        '#attributes' => ['class' => ['pre-existing-class']],
+      ],
+    ];
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $classes = $result['1']['#attributes']['class'];
+    $this->assertContains('pre-existing-class', $classes, 'Pre-existing CSS classes must not be removed.');
+    $this->assertContains('visually-hidden', $classes, 'visually-hidden must also be present.');
+    $this->assertContains('saved-card__radio', $classes, 'saved-card__radio must also be present.');
+  }
+
+  /**
+   * Tests that the element is returned (not modified in-place, not NULL).
+   *
+   * #after_build callbacks must always return the element array.
+   */
+  public function testCallbackAlwaysReturnsElement(): void {
+    $element = $this->buildElement([], []);
+
+    $result = store_fulfillment_payment_radios_after_build($element, new FormState());
+
+    $this->assertIsArray($result);
+    $this->assertSame($element['#type'], $result['#type']);
+  }
+
+}


### PR DESCRIPTION
…#106

- Add PaymentRadiosAfterBuildTest (Kernel): 12 tests directly exercising store_fulfillment_payment_radios_after_build() callback. Covers card data stamping, visually-hidden class, saved-card__radio class, non-numeric option handling, missing key fallback, and always-returns-array guarantee.

- Add 4 saved-card regression tests to PaymentPaneFormAlterTest (Functional): testSavedCardRadioInputsExistInDom, testPaymentPaneHasSavedCardsClass, testSavedCardRadioInputsHaveVisuallyHiddenClass, testPaymentPaneLacksSavedCardsClassWithNoSavedMethods.

- Fix createSavedPaymentMethodForAdminUser(): add billing profile with US address (required by PaymentMethodStorage::loadReusable() which filters on store billing_countries = ['US']).

- Fix store_fulfillment.module: make duccinis_1984_olympics library attachment conditional on theme being installed (prevents UnknownExtensionException in tests running under stark theme).

- Fix phpunit.xml: correct SIMPLETEST_BASE_URL from duccinisv3 to duccinisv4.

All tests: Kernel 12/12, Functional 7/7.

Closes #106.