### PR TITLE
fix: close issue #109 — copy duccinis_archive module from V3 → V4

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -22,6 +22,7 @@ module:
   dblog: 0
   drupal_cms_helper: 0
   drupical: 0
+  duccinis_archive: 0
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   easy_email: 0

--- a/config/sync/system.action.duccinis_archive_product.yml
+++ b/config/sync/system.action.duccinis_archive_product.yml
@@ -1,0 +1,13 @@
+uuid: 3e23ac77-342d-46e2-9fa1-707fefb2e0d9
+langcode: en
+status: true
+dependencies:
+  module:
+    - duccinis_archive
+_core:
+  default_config_hash: gdptjeShh8haVRXWunGCpT2wo5GGHRRjX_ZOtXh5Dho
+id: duccinis_archive_product
+label: 'Archive product'
+type: commerce_product
+plugin: duccinis_archive_product
+configuration: {  }

--- a/config/sync/system.action.duccinis_unarchive_product.yml
+++ b/config/sync/system.action.duccinis_unarchive_product.yml
@@ -1,0 +1,13 @@
+uuid: fc7a34d0-9321-4595-ad9c-a8439005ca49
+langcode: en
+status: true
+dependencies:
+  module:
+    - duccinis_archive
+_core:
+  default_config_hash: Eq2AgCSwSl6HmWSLP7gaEpPpuvc4p2xxFIR7tTrYwkA
+id: duccinis_unarchive_product
+label: 'Unarchive product'
+type: commerce_product
+plugin: duccinis_unarchive_product
+configuration: {  }


### PR DESCRIPTION
Closes #109

## Summary

- Module was already present in V4 (identical to V3 source — zero diff)
- Enabled `duccinis_archive` cleanly with `ddev drush en duccinis_archive`
- Exported `core.extension.yml` (module added to enabled list) and two action configs (`system.action.duccinis_archive_product.yml`, `system.action.duccinis_unarchive_product.yml`)

## Tests

All 13 Kernel tests pass (243 assertions, 0 failures).