### PR TITLE
docs: close issue #77 — fix stale V3 analytics references

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -46,13 +46,15 @@ window.dataLayer.push({
 ## Implementation
 
 - **Data attributes** are emitted server-side by
-  `duccinis_1984_olympics_preprocess_commerce_checkout_form()` in
-  `web/themes/custom/duccinis_1984_olympics/includes/commerce.theme`.
+  `CheckoutProgressBarBlock::buildSteps()` in
+  `web/modules/custom/store_fulfillment/src/Plugin/Block/CheckoutProgressBarBlock.php`
+  and rendered by the SDC component
+  `web/themes/custom/duccinis_1984_olympics/components/checkout-progress/checkout-progress.twig`.
 - **JS behavior** lives in
   `web/themes/custom/duccinis_1984_olympics/src/js/checkout-progress-analytics.js`
   (library: `duccinis_1984_olympics/checkout-progress-analytics`).
-- Library is attached **only** on pages that render the checkout progress bar
-  (i.e. Commerce checkout pages), so there is no global JS bloat.
+- Library is attached via `CheckoutProgressBarBlock::build()` — **only** on pages
+  where the block renders — so there is no global JS bloat.
 
 ---
 

--- a/web/themes/custom/duccinis_1984_olympics/src/js/checkout-progress-analytics.js
+++ b/web/themes/custom/duccinis_1984_olympics/src/js/checkout-progress-analytics.js
@@ -11,8 +11,9 @@
  *     order_id:  '27',              // Commerce order ID (string)
  *   }
  *
- * Data attributes emitted by
- * duccinis_1984_olympics_preprocess_commerce_checkout_form() in commerce.theme:
+ * Data attributes emitted by CheckoutProgressBarBlock::buildSteps() in
+ * web/modules/custom/store_fulfillment/src/Plugin/Block/CheckoutProgressBarBlock.php
+ * and rendered via the SDC component checkout-progress.twig:
  *   data-funnel-event, data-from-step, data-to-step, data-order-id
  */
 


### PR DESCRIPTION
Closes #77

## Changes (documentation only — no functional code changes)

### `ANALYTICS.md`
- Fixed "Implementation" section: replaced stale reference to `duccinis_1984_olympics_preprocess_commerce_checkout_form()` in `commerce.theme` with the correct V4 implementation: `CheckoutProgressBarBlock::buildSteps()` + `checkout-progress.twig` SDC component + library attached via `CheckoutProgressBarBlock::build()`.

### `src/js/checkout-progress-analytics.js`
- Fixed `@file` docblock: replaced reference to `commerce.theme` preprocess with `CheckoutProgressBarBlock` and the SDC component.

## Acceptance Criteria Verified

- ✅ `ANALYTICS.md` Implementation section references `CheckoutProgressBarBlock` + `checkout-progress.twig`
- ✅ `checkout-progress-analytics.js` `@file` references SDC component, not `commerce.theme`
- ✅ All other `ANALYTICS.md` content (GTM/GA4 setup, payloads) untouched
- ✅ No functional code changes