### PR TITLE
test: close issue #126 — add entity-query visibility test for archived products

### DIFF
--- a/web/modules/custom/duccinis_archive/tests/src/Kernel/ProductArchiveSubscriberTest.php
+++ b/web/modules/custom/duccinis_archive/tests/src/Kernel/ProductArchiveSubscriberTest.php
@@ -169,4 +169,38 @@ class ProductArchiveSubscriberTest extends CommerceKernelTestBase {
     $this->assertFalse($first->isPublished(), 'Manually unpublished variation stays unpublished after unrelated product save.');
   }
 
+  /**
+   * Archived product is excluded from a published entity query.
+   *
+   * Views and Commerce listings query for published (status=1) products only.
+   * This test simulates that query to confirm archived products are invisible
+   * from any listing the moment they are archived.
+   *
+   * @covers ::onProductPresave
+   */
+  public function testArchivedProductIsExcludedFromPublishedEntityQuery(): void {
+    $product = $this->createActiveProduct();
+    $product_id = $product->id();
+
+    // Sanity check: the product appears in a published-only query.
+    $ids_before = \Drupal::entityQuery('commerce_product')
+      ->condition('status', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    $this->assertContains((string) $product_id, array_values($ids_before),
+      'Published product appears in status=1 entity query before archiving.');
+
+    // Archive the product.
+    $product->set('field_archived', TRUE);
+    $product->save();
+
+    // The archived product must no longer appear in a published-only query.
+    $ids_after = \Drupal::entityQuery('commerce_product')
+      ->condition('status', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    $this->assertNotContains((string) $product_id, array_values($ids_after),
+      'Archived product is excluded from status=1 entity query (hidden from views).');
+  }
+
 }


### PR DESCRIPTION
Closes #126

## What

Adds `testArchivedProductIsExcludedFromPublishedEntityQuery()` to `ProductArchiveSubscriberTest`.

The `duccinis_archive` module already had 13 Kernel tests across four classes (archiving/unarchiving behaviour, audit logging, action plugins, AJAX controller). The one gap was an explicit test for the **'hides from views'** acceptance criterion.

The new test:
1. Creates a published product and verifies it appears in a `status=1` entity query (the same query Commerce Views uses for all product listings).
2. Archives the product.
3. Asserts the product is absent from the same `status=1` query — confirming it is hidden from all views/listings.

## Result

```
Tests: 14, Assertions: 260 — OK
```

Run with: `ddev exec vendor/bin/phpunit --testsuite=duccinis_archive`