### PR TITLE
feat: close #130 #131 — V3 CSV port, feeds config, feed entity creation script, product import

### DIFF
--- a/config/sync/field.field.commerce_product.beverages.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.beverages.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 3b0c9c2e-6c1a-4c7f-9b20-b7633c2c4f01
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.beverages
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.beverages.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: beverages
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.chicken_wings.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.chicken_wings.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 7f1e2d3c-4b5a-6c7d-8e9f-0a1b2c3d4e6f
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.chicken_wings
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.chicken_wings.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: chicken_wings
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.desserts.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.desserts.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 6f2a1c3d-8b4e-4c2f-9a7b-1c2d3e4f5a6b
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.desserts
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.desserts.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: desserts
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.fresh_submarines.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.fresh_submarines.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: ef8afb7e-fe08-42f1-9912-67ed0f1d17cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.fresh_submarines
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.fresh_submarines.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: fresh_submarines
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.homemade_pasta.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.homemade_pasta.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 2f8b6a9e-3c7a-4b1e-9f2d-67f9b8a1c3d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.homemade_pasta
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.homemade_pasta.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: homemade_pasta
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.pizza.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.pizza.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 2a3b3c4d-5e6f-4701-9a8b-1234567890ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.pizza
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.pizza.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: pizza
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.salad.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.salad.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 9b1e7e75-3a0f-4f9a-9b3c-0a2c5d9a7c21
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.salad
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.salad.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: salad
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product.side_orders.feeds_item.yml
+++ b/config/sync/field.field.commerce_product.side_orders.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: c1a2b3c4-d5e6-47f8-9a0b-b1c2d3e4f5a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_type.side_orders
+    - field.storage.commerce_product.feeds_item
+  module:
+    - feeds
+id: commerce_product.side_orders.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+bundle: side_orders
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.beverage.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.beverage.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 6a4d2b83-8f80-4f8b-8d5b-4d5b645c9e11
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.beverage
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.beverage.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: beverage
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.fresh_buffalo_wings.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.fresh_buffalo_wings.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 9b7a4ee4-3f6c-4d0f-9a1c-2b4c6d8e9f01
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.fresh_buffalo_wings
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.fresh_buffalo_wings.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: fresh_buffalo_wings
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.fries_sticks_chips.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.fries_sticks_chips.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 6b7c8d9e-0a1b-4c2d-9e8f-7a6b5c4d3e2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.fries_sticks_chips
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.fries_sticks_chips.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: fries_sticks_chips
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.pasta_type.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.pasta_type.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 7a8b9c0d-1e2f-4a5b-9c0d-1e2f3a4b5c6d
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.pasta_type
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.pasta_type.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: pasta_type
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.pizza_custom.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.pizza_custom.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 5c1d5f0e-8b0b-4b1f-9b7a-7d9a0c1f2a3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.pizza_custom
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.pizza_custom.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: pizza_custom
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.pizza_delightz.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.pizza_delightz.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 7b8c9d0e-1f2a-43bc-9d4e-abcdef012345
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.pizza_delightz
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.pizza_delightz.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: pizza_delightz
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.recipe.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.recipe.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 1a2b3c4d-5e6f-4789-9a0b-b1c2d3e4f5a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.recipe
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.recipe.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: recipe
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.salad.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.salad.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 8f2a9e1c-1b3d-4e5f-9a7b-2c4d6e8f0a12
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.salad
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.salad.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: salad
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.stromboli.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.stromboli.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 2f3a4b5c-6d7e-4890-9a1b-2c3d4e5f6a7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.stromboli
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.stromboli.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: stromboli
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.field.commerce_product_variation.submarine_sandwich.feeds_item.yml
+++ b/config/sync/field.field.commerce_product_variation.submarine_sandwich.feeds_item.yml
@@ -1,0 +1,23 @@
+uuid: 5097dbb7-ec5f-4cea-a2d2-c059ba1775f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_product.commerce_product_variation_type.submarine_sandwich
+    - field.storage.commerce_product_variation.feeds_item
+  module:
+    - feeds
+id: commerce_product_variation.submarine_sandwich.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+bundle: submarine_sandwich
+label: 'Feeds item'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:feeds_feed'
+  handler_settings: {  }
+field_type: feeds_item

--- a/config/sync/field.storage.commerce_product.feeds_item.yml
+++ b/config/sync/field.storage.commerce_product.feeds_item.yml
@@ -1,0 +1,20 @@
+uuid: cb7d1427-03bb-43b4-a95c-0b7ed1481b40
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+    - feeds
+id: commerce_product.feeds_item
+field_name: feeds_item
+entity_type: commerce_product
+type: feeds_item
+settings:
+  target_type: feeds_feed
+module: feeds
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.commerce_product_variation.feeds_item.yml
+++ b/config/sync/field.storage.commerce_product_variation.feeds_item.yml
@@ -1,0 +1,20 @@
+uuid: 787d5004-1eb5-4f17-9d4d-b909ce671d06
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_product
+    - feeds
+id: commerce_product_variation.feeds_item
+field_name: feeds_item
+entity_type: commerce_product_variation
+type: feeds_item
+settings:
+  target_type: feeds_feed
+module: feeds
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/scripts/create_feeds.php
+++ b/scripts/create_feeds.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * @file
+ * Creates Feeds feed entities for all product categories.
+ *
+ * Run with:
+ *   ddev drush php:script scripts/create_feeds.php
+ *
+ * ----------------------------------------------------------------------
+ * REUSE GUIDE — Adapting for a new restaurant chain
+ * ----------------------------------------------------------------------
+ *
+ * 1. FEED TYPES ($feeds_to_create array)
+ *    Each entry maps to a `feeds.feed_type.*` config entity that must
+ *    already exist in config/sync and be imported into the DB.
+ *    - 'type'  → machine name of the feed type (feeds.feed_type.<id>)
+ *    - 'label' → human-readable name shown in /admin/content/feed
+ *    - 'csv'   → filename in web/sites/default/files/
+ *
+ *    Convention: one *_product feed + one *_variations feed per category,
+ *    both pointing at the same CSV file. The product feed creates the
+ *    Commerce Product entity; the variations feed creates the Commerce
+ *    Product Variation entities and links them to the product.
+ *
+ * 2. BASE URL ($base)
+ *    Point to your site's public files URL. For DDEV local:
+ *      https://<project>.ddev.site/sites/default/files/
+ *    For production:
+ *      https://<domain>/sites/default/files/
+ *
+ * 3. CSV FORMAT
+ *    The CSV columns must match the custom_sources defined in the
+ *    corresponding feeds.feed_type.*.yml config file. Typical columns:
+ *      product_id, sku, price__number, <attribute_column>, stores
+ *    See Commerce_Product_Importing.md for the full column reference.
+ *
+ * 4. IMPORT ORDER
+ *    Always import *_product feeds FIRST, then *_variations feeds.
+ *    Products must exist before variations can be linked to them.
+ *
+ *    Run all product feeds:
+ *      for type in beverages_product buffalo_wings_product ...; do
+ *        ddev drush feeds:import $type --import-disabled -y
+ *      done
+ *
+ *    Then all variation feeds:
+ *      for type in beverages_variations buffalo_wings_variations ...; do
+ *        ddev drush feeds:import $type --import-disabled -y
+ *      done
+ *
+ * 5. RE-RUNNING
+ *    The script is idempotent — it skips any feed type that already has
+ *    an entity in the DB. Safe to run multiple times.
+ *
+ * 6. ADDING A NEW CATEGORY
+ *    a. Add a feeds.feed_type.<id>_product.yml and
+ *       feeds.feed_type.<id>_variations.yml to config/sync (copy an
+ *       existing one and adjust processor/mappings).
+ *    b. Run `ddev drush cim -y` to activate the new feed type.
+ *    c. Add an entry to $feeds_to_create below.
+ *    d. Re-run this script: `ddev drush php:script scripts/create_feeds.php`
+ *    e. Run `ddev drush feeds:import <id>_product -y` then
+ *       `ddev drush feeds:import <id>_variations -y`.
+ * ----------------------------------------------------------------------
+ */
+
+// Base URL for CSV files. Change this when deploying to production.
+$base = 'https://duccinisv4.ddev.site/sites/default/files/';
+
+// List of feed entities to create.
+// Each entry: feed type machine name | human label | CSV filename.
+$feeds_to_create = [
+  // Beverages
+  ['type' => 'beverages_product',            'label' => 'Beverages product',                   'csv' => 'beverages.csv'],
+  ['type' => 'beverages_variations',          'label' => 'Beverages variation',                 'csv' => 'beverages.csv'],
+  // Buffalo Wings
+  ['type' => 'buffalo_wings_product',         'label' => 'Fresh Buffalo Wings product',         'csv' => 'buffalo_wings.csv'],
+  ['type' => 'buffalo_wings_variations',      'label' => 'Fresh Buffalo Wings variation',       'csv' => 'buffalo_wings.csv'],
+  // Desserts
+  ['type' => 'desserts_product',              'label' => 'Desserts product',                    'csv' => 'desserts.csv'],
+  ['type' => 'desserts_variations',           'label' => 'Desserts variation',                  'csv' => 'desserts.csv'],
+  // Fresh Submarines
+  ['type' => 'fresh_submarines_product',      'label' => 'Fresh submarines product',            'csv' => 'fresh_submarines.csv'],
+  ['type' => 'fresh_submarines_variations',   'label' => 'Fresh submarines variation',          'csv' => 'fresh_submarines.csv'],
+  // Fries, Sticks & Chips
+  ['type' => 'fries_sticks_chips_product',    'label' => 'Fries, chips, and sticks product',   'csv' => 'fries_sticks_chips.csv'],
+  ['type' => 'fries_sticks_chips_variations', 'label' => 'Fries, chips, and sticks variation', 'csv' => 'fries_sticks_chips.csv'],
+  // Homemade Pasta
+  ['type' => 'homemade_pasta_product',        'label' => 'Homemade pasta product',              'csv' => 'homemade_pasta.csv'],
+  ['type' => 'homemade_pasta_variations',     'label' => 'Homemade pasta variation',            'csv' => 'homemade_pasta.csv'],
+  // Pizza Delights
+  ['type' => 'pizza_delights_product',        'label' => 'Pizza Delights Product',              'csv' => 'pizza_delights.csv'],
+  ['type' => 'pizza_delights_variations',     'label' => 'Pizza Delights Variation',            'csv' => 'pizza_delights.csv'],
+  // Pizza
+  ['type' => 'pizza_product',                 'label' => 'Pizza Product',                       'csv' => 'pizza.csv'],
+  ['type' => 'pizza_variations',              'label' => 'Pizza Variation',                     'csv' => 'pizza.csv'],
+  // Salads
+  ['type' => 'salads_product',                'label' => 'Salads product',                      'csv' => 'salads.csv'],
+  ['type' => 'salads_variations',             'label' => 'Salads variation',                    'csv' => 'salads.csv'],
+  // Side Orders
+  ['type' => 'side_orders_product',           'label' => 'Side orders product',                 'csv' => 'side_orders.csv'],
+  // Stromboli — no known variation type in V3; add variations entry if needed.
+  // ['type' => 'stromboli_product',          'label' => 'Stromboli product',                   'csv' => 'stromboli.csv'],
+  // ['type' => 'stromboli_variations',       'label' => 'Stromboli variation',                 'csv' => 'stromboli.csv'],
+];
+
+$storage = \Drupal::entityTypeManager()->getStorage('feeds_feed');
+$created = 0;
+$skipped = 0;
+
+echo "=== Creating Feeds feed entities ===\n\n";
+
+// Build a simple map of existing type -> fid using a direct DB query.
+// (loadByProperties() triggers a feeds_item field query that fails before
+// the field storage exists — use Database API instead.)
+$existing_types = \Drupal::database()
+  ->select('feeds_feed', 'f')
+  ->fields('f', ['fid', 'type'])
+  ->execute()
+  ->fetchAllKeyed(1, 0); // type => fid
+
+foreach ($feeds_to_create as $def) {
+  if (isset($existing_types[$def['type']])) {
+    echo "SKIP    [{$existing_types[$def['type']]}] {$def['label']} (already exists)\n";
+    $skipped++;
+    continue;
+  }
+
+  $feed = $storage->create([
+    'type'   => $def['type'],
+    'title'  => $def['label'],
+    'source' => $base . $def['csv'],
+    'status' => 1,
+    'uid'    => 1,
+  ]);
+  $feed->save();
+  echo "CREATED [{$feed->id()}] {$def['label']} → {$base}{$def['csv']}\n";
+  $created++;
+}
+
+echo "\n=== Summary: {$created} created, {$skipped} skipped ===\n";
+echo "\nAll feed entities:\n";
+$rows = \Drupal::database()
+  ->select('feeds_feed', 'f')
+  ->fields('f', ['fid', 'type', 'source'])
+  ->orderBy('fid')
+  ->execute()
+  ->fetchAll();
+foreach ($rows as $row) {
+  echo "  [{$row->fid}] {$row->type} → {$row->source}\n";
+}
+
+echo "\n=== Next steps ===\n";
+echo "Import products FIRST, then variations:\n\n";
+
+$product_types = array_filter($feeds_to_create, fn($d) => str_ends_with($d['type'], '_product'));
+$variation_types = array_filter($feeds_to_create, fn($d) => str_ends_with($d['type'], '_variations'));
+
+foreach ($product_types as $d) {
+  echo "  ddev drush feeds:import {$d['type']} --import-disabled -y\n";
+}
+echo "\n";
+foreach ($variation_types as $d) {
+  echo "  ddev drush feeds:import {$d['type']} --import-disabled -y\n";
+}


### PR DESCRIPTION
## Summary

Closes #130
Closes #131

### What was done

Port V3 product catalog to V4 via Feeds:

1. **Feeds modules enabled**: feeds, feeds_log, commerce_feeds, feeds_tamper, duccinis_feeds_fix
2. **21 feed type configs** (feeds.feed_type.*.yml) copied from V3 into config/sync
3. **20 feeds_item field configs** copied from V3:
   - `field.storage.commerce_product.feeds_item.yml`
   - `field.storage.commerce_product_variation.feeds_item.yml`
   - 8 `field.field.commerce_product.*.feeds_item.yml`
   - 10 `field.field.commerce_product_variation.*.feeds_item.yml`
4. **`scripts/create_feeds.php`** — idempotent Drush PHP script to create all 19 Feeds content entities (documented for reuse with other restaurant chains)
5. **Products imported**: 72 products, 140 variations via `ddev drush feeds:import`

### Count discrepancy with V3 (expected)

V3: 74 products — V4: 72 products (diff = 2, both intentional)

| Missing | Reason |
|---|---|
| `famous_stromboli` product | No stromboli feed exists in V3 — intentionally excluded |
| `Extra Sauce` (chicken_wings type) | Manually created in V3, not in any CSV — not migrated |

### Verification

- `/menu` returns HTTP 200 with full product catalog
- All 10 product feeds and 9 variation feeds imported cleanly
- Two minor attribute warnings in fresh_submarines and salads variations (orphaned size options) — items still created correctly

### Running the import on a fresh install

```bash
# 1. Import config (installs feed types + feeds_item fields)
ddev drush cim -y

# 2. Copy CSVs to files/ (gitignored)
cp <source>/*.csv web/sites/default/files/

# 3. Create feed entities
ddev drush php:script scripts/create_feeds.php

# 4. Import products first, then variations
for fid in 1 3 5 7 9 11 13 15 17 19; do ddev drush feeds:import $fid --import-disabled -y; done
for fid in 2 4 6 8 10 12 14 16 18; do ddev drush feeds:import $fid --import-disabled -y; done
```