### PR TITLE
feat: close issue #138 — export V3 store entity data

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -362,9 +362,10 @@
 
 ### Issues
 
-- [ ] **#10.1 — Export V3 store entity data**
+- [x] **#10.1 — Export V3 store entity data** ✅ closed #138
   Export the three store entities (Adams Morgan DC, Arlington VA, 7th Street NW) with their `delivery_radius`, `store_location` (lat/lon), and store hours fields.
   Options: `ddev drush dce` (default content), or manual `drush sql-query` export.
+  Export written to `scripts/data/v3-stores-export.json`; import script at `scripts/import-stores.php`.
   _Done when: Store data is in a format importable to V4._
 
 - [ ] **#10.2 — Verify V4 store field config matches V3**

--- a/scripts/data/v3-stores-export.json
+++ b/scripts/data/v3-stores-export.json
@@ -1,0 +1,79 @@
+[
+  {
+    "_comment": "Exported from duccinisV3 on 2026-03-15 via ddev drush php:eval",
+    "_note": "Name corrected from typo 'Adams Morgen DC' → 'Adams Morgan DC'",
+    "id": 1,
+    "uuid": "2b041c08-8f33-48a9-a52c-ff1b78d10ae3",
+    "name": "Adams Morgan DC",
+    "type": "online",
+    "mail": "geena@amstercad.com",
+    "default_currency": "USD",
+    "timezone": "America/New_York",
+    "uid": 1,
+    "delivery_radius": "4.00",
+    "store_location": {
+      "lat": 38.9167879,
+      "lon": -77.0412164,
+      "wkt": "POINT (-77.0412164 38.9167879)"
+    },
+    "store_hours": "Monday|11:00|04:00\r\nTuesday|11:00|04:00\r\nWednesday|11:00|04:00\r\nThursday|11:00|04:00\r\nFriday|11:00|05:00\r\nSaturday|11:00|05:00\r\nSunday|11:00|04:00",
+    "address": {
+      "country_code": "US",
+      "administrative_area": "DC",
+      "locality": "Washington",
+      "postal_code": "20009",
+      "address_line1": "1778 U Street NW",
+      "address_line2": ""
+    }
+  },
+  {
+    "id": 2,
+    "uuid": "82e8c469-6caf-4cbe-b172-08c00d5f0270",
+    "name": "Arlington VA",
+    "type": "online",
+    "mail": "chuck@amstercad.com",
+    "default_currency": "USD",
+    "timezone": "America/New_York",
+    "uid": 1,
+    "delivery_radius": "4.50",
+    "store_location": {
+      "lat": 38.8695823,
+      "lon": -77.1263207,
+      "wkt": "POINT (-77.1263207 38.8695823)"
+    },
+    "store_hours": "Monday|11:00|01:00\r\nTuesday|11:00|01:00\r\nWednesday|11:00|01:00\r\nThursday|11:00|01:00\r\nFriday|11:00|02:00\r\nSaturday|11:00|02:00\r\nSunday|11:00|01:00",
+    "address": {
+      "country_code": "US",
+      "administrative_area": "VA",
+      "locality": "Falls Church",
+      "postal_code": "22041",
+      "address_line1": "3420 Carlyn Hill Dr.",
+      "address_line2": ""
+    }
+  },
+  {
+    "id": 3,
+    "uuid": "38eddb67-7991-416b-b27b-feeec63dea85",
+    "name": "7th Street NW",
+    "type": "online",
+    "mail": "lee@amstercad.com",
+    "default_currency": "USD",
+    "timezone": "America/New_York",
+    "uid": 1,
+    "delivery_radius": "4.00",
+    "store_location": {
+      "lat": 38.9106648,
+      "lon": -77.021574,
+      "wkt": "POINT (-77.021574 38.9106648)"
+    },
+    "store_hours": "Monday|11:00|01:00\r\nTuesday|11:00|01:00\r\nWednesday|11:00|01:00\r\nThursday|11:00|01:00\r\nFriday|11:00|02:00\r\nSaturday|11:00|02:00\r\nSunday|11:00|01:00",
+    "address": {
+      "country_code": "US",
+      "administrative_area": "DC",
+      "locality": "Washington",
+      "postal_code": "20001",
+      "address_line1": "1537 7th Street NW",
+      "address_line2": ""
+    }
+  }
+]

--- a/scripts/import-stores.php
+++ b/scripts/import-stores.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file
+ * Import V3 store entities into V4.
+ *
+ * Reads scripts/data/v3-stores-export.json and creates/updates all three
+ * Duccinis store entities with their delivery_radius, store_location,
+ * store_hours, and address fields.
+ *
+ * Usage (from V4 project root):
+ *   ddev drush php:script scripts/import-stores.php
+ *
+ * Idempotent: existing stores are updated, not duplicated.
+ * Issue: #10.3 — Import store data into V4.
+ */
+
+declare(strict_types=1);
+
+$data_file = __DIR__ . '/data/v3-stores-export.json';
+if (!file_exists($data_file)) {
+  echo "ERROR: $data_file not found.\n";
+  exit(1);
+}
+
+$stores_data = json_decode(file_get_contents($data_file), TRUE);
+if (!$stores_data) {
+  echo "ERROR: Failed to parse $data_file.\n";
+  exit(1);
+}
+
+foreach ($stores_data as $data) {
+  // Skip meta-only entries.
+  if (!isset($data['id'])) {
+    continue;
+  }
+
+  $store_id = (int) $data['id'];
+  $store = \Drupal\commerce_store\Entity\Store::load($store_id);
+
+  if ($store) {
+    echo "Updating existing store #{$store_id}: {$data['name']}\n";
+  }
+  else {
+    echo "Creating store #{$store_id}: {$data['name']}\n";
+    $store = \Drupal\commerce_store\Entity\Store::create([
+      'type' => $data['type'],
+      'uid' => $data['uid'],
+      'uuid' => $data['uuid'],
+    ]);
+  }
+
+  $store->setName($data['name']);
+  $store->setEmail($data['mail']);
+  $store->setDefaultCurrencyCode($data['default_currency']);
+  $store->set('timezone', $data['timezone']);
+
+  // Address.
+  $store->setAddress([
+    'country_code'       => $data['address']['country_code'],
+    'administrative_area' => $data['address']['administrative_area'],
+    'locality'           => $data['address']['locality'],
+    'postal_code'        => $data['address']['postal_code'],
+    'address_line1'      => $data['address']['address_line1'],
+    'address_line2'      => $data['address']['address_line2'] ?? '',
+  ]);
+
+  // Custom fields.
+  if ($store->hasField('delivery_radius')) {
+    $store->set('delivery_radius', $data['delivery_radius']);
+  }
+  else {
+    echo "  WARNING: delivery_radius field missing on store entity — skipping.\n";
+  }
+
+  if ($store->hasField('store_location')) {
+    $store->set('store_location', $data['store_location']['wkt']);
+  }
+  else {
+    echo "  WARNING: store_location field missing on store entity — skipping.\n";
+  }
+
+  if ($store->hasField('store_hours')) {
+    $store->set('store_hours', $data['store_hours']);
+  }
+  else {
+    echo "  WARNING: store_hours field missing on store entity — skipping.\n";
+  }
+
+  $store->save();
+  echo "  Saved store #{$store_id} OK.\n";
+}
+
+echo "\nDone. Run 'ddev drush cr' if any display issues appear.\n";


### PR DESCRIPTION
Closes #138

## What this does
- Exports all 3 V3 stores via `ddev drush php:eval` in read-only mode
- `scripts/data/v3-stores-export.json` — full store data (id, uuid, name, address, delivery_radius, store_location lat/lon, store_hours)
- `scripts/import-stores.php` — idempotent Drush import script (used in #10.3)
- Note: V3 typo corrected: 'Adams Morgen DC' → 'Adams Morgan DC'

## Stores exported
| Store | Radius | Lat | Lon |
|-------|--------|-----|-----|
| Adams Morgan DC | 4.00 mi | 38.9167879 | -77.0412164 |
| Arlington VA | 4.50 mi | 38.8695823 | -77.1263207 |
| 7th Street NW | 4.00 mi | 38.9106648 | -77.021574 |