### PR TITLE
feat(theme): global homepage SCSS primitives

### DIFF
--- a/web/themes/custom/duccinis_1984_olympics/src/scss/components/_homepage.scss
+++ b/web/themes/custom/duccinis_1984_olympics/src/scss/components/_homepage.scss
@@ -145,3 +145,101 @@ a.btn-ghost {
     }
   }
 }
+
+// ── Nav internals ──────────────────────────────────────────────────────────
+// Logo, nav links and Order button that live inside .site-nav.
+// .site-nav structural styles are above.
+.nav-logo {
+  font-family: var(--duccini-f-display);
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  letter-spacing: 0.08em;
+  color: var(--duccini-yellow);
+  text-decoration: none;
+  line-height: 1;
+
+  em {
+    color: var(--duccini-red);
+    font-style: normal;
+  }
+}
+
+.nav-links {
+  display: flex;
+  gap: 2.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  a {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--duccini-muted);
+    text-decoration: none;
+    transition: color 0.2s;
+
+    &:hover {
+      color: var(--duccini-yellow);
+    }
+  }
+
+  @media (max-width: 720px) {
+    display: none;
+  }
+}
+
+.nav-order {
+  display: inline-block;
+  font-family: var(--duccini-f-head);
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.65rem 1.6rem;
+  background: var(--duccini-red);
+  color: #fff;
+  text-decoration: none;
+  transition: background 0.2s, transform 0.15s;
+  clip-path: polygon(6px 0%, 100% 0%, calc(100% - 6px) 100%, 0% 100%);
+
+  &:hover {
+    background: var(--duccini-orange);
+    color: #fff;
+    transform: translateY(-1px);
+  }
+}
+
+// ── Shared section primitives ──────────────────────────────────────────────
+// Used by non-SDC Drupal sections that need a standard padding wrapper.
+.section {
+  padding: 6rem 2rem;
+}
+
+.section-title {
+  font-family: var(--duccini-f-display);
+  font-size: clamp(3.2rem, 7vw, 6.5rem);
+  line-height: 0.92;
+  letter-spacing: 0.02em;
+  margin-bottom: 1.5rem;
+}
+
+// ── Order CTA button ───────────────────────────────────────────────────────
+// Large clip-path button used in the order-band section.
+.btn-order {
+  display: inline-block;
+  font-family: var(--duccini-f-display);
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  letter-spacing: 0.18em;
+  padding: 1.2rem 4.5rem;
+  background: #0b0a08;
+  color: var(--duccini-yellow);
+  text-decoration: none;
+  clip-path: polygon(14px 0%, 100% 0%, calc(100% - 14px) 100%, 0% 100%);
+  transition: background 0.25s, transform 0.2s;
+
+  &:hover {
+    background: #1c1810;
+    color: var(--duccini-yellow);
+    transform: scale(1.04);
+  }
+}


### PR DESCRIPTION
Closes #206

## Changes
- Added `.nav-logo`, `.nav-links`, `.nav-order` nav content styles from prototype
- Added `.section` shared padding and `.section-title` display heading primitive
- Added `.btn-order` large clip-path CTA for the order-band section
- All other primitives (.site-nav, .clip, .section-label, .reveal, a.btn-primary, a.btn-ghost) were pre-existing

## Quality gates
- `npm run dev` exits 0 ✅
- `npx stylelint` — 0 errors ✅