### PR TITLE
fix: close issue #209 — nav scroll behavior (fix isFrontPage detection)

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: /user/login
   404: ''
-  front: /home
+  front: /page/1
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
Closes #209

## What
The `navScroll` Drupal behavior was already implemented in `homepage-reveal.js` (issue #191), but the `duccinis_1984_olympics/homepage` library was **never being attached** to the front page.

## Root Cause
`system.site page.front` was set to the path alias `/home` rather than the internal Drupal path `/page/1`.

Drupal's `PathMatcher::isFrontPage()` computes:
```
'/' + Url::fromRouteMatch()->getInternalPath()  // = '/page/1'
```
and compares it against `page.front`. With `page.front = '/home'`, these never match → `isFrontPage()` always returned `false` → homepage library was never loaded.

## Fix
Changed `config/sync/system.site.yml` `page.front` from `/home` to `/page/1`.

## Verification
- `isFront: true` now appears in `drupalSettings.path` on the front page
- `duccinis_1984_olympics/homepage` library is now in the aggregated JS include (confirmed by decoding the `include=` parameter)  
- `navScroll` behavior attaches to `.site-nav` and toggles `.scrolled` at 60px scroll threshold ✓
- Passive scroll listener, no CLS, idempotent guard all verified in source code
- `/home` now correctly redirects to `/` (canonical front page URL) via Redirect module's canonical enforcement