### PR TITLE
fix: close issue #210 — consolidate all Google Fonts into fonts library in libraries.yml

### DIFF
--- a/web/themes/custom/duccinis_1984_olympics/duccinis_1984_olympics.info.yml
+++ b/web/themes/custom/duccinis_1984_olympics/duccinis_1984_olympics.info.yml
@@ -18,7 +18,7 @@ regions:
   page_bottom: 'Page bottom'
   footer: Footer
 libraries:
-  - duccinis_1984_olympics/google-fonts-dm-sans
+  - duccinis_1984_olympics/fonts
   - duccinis_1984_olympics/style
 ckeditor5-stylesheets:
   - build/css/main.style.css

--- a/web/themes/custom/duccinis_1984_olympics/duccinis_1984_olympics.libraries.yml
+++ b/web/themes/custom/duccinis_1984_olympics/duccinis_1984_olympics.libraries.yml
@@ -1,7 +1,7 @@
-google-fonts-dm-sans:
+fonts:
   css:
     theme:
-      'https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap':
+      'https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Archivo+Black&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&display=swap':
         type: external
         minified: true
 


### PR DESCRIPTION
Closes #210

## What changed
- Replaced the  library (DM Sans only) with a unified  library in  declaring **Bebas Neue**, **Archivo Black**, and **DM Sans** via a single external CSS URL.
- Updated  global libraries list to reference  instead.

## Verification
- No inline `<link>` tags exist in any Twig template — confirmed by grep.
- Smoke test confirms all three fonts render via Drupal's asset pipeline.
- `ddev drush cr` exits 0.