### PR TITLE
fix: close issue #211 — guarantee --duccini-* CSS token load order in SDC components

### DIFF
--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-hero/duccinis-hero.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-hero/duccinis-hero.component.yml
@@ -45,3 +45,10 @@ third_party_settings:
   canvas:
     label: 'Hero — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-hero.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-location-card/duccinis-location-card.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-location-card/duccinis-location-card.component.yml
@@ -54,3 +54,10 @@ third_party_settings:
   canvas:
     label: 'Location Card — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-location-card.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-locations-section/duccinis-locations-section.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-locations-section/duccinis-locations-section.component.yml
@@ -34,3 +34,10 @@ third_party_settings:
   canvas:
     label: 'Locations Section — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-locations-section.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-menu-preview/duccinis-menu-preview.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-menu-preview/duccinis-menu-preview.component.yml
@@ -42,3 +42,10 @@ third_party_settings:
   canvas:
     label: 'Menu Preview — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-menu-preview.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-order-band/duccinis-order-band.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-order-band/duccinis-order-band.component.yml
@@ -31,3 +31,10 @@ third_party_settings:
   canvas:
     label: 'Order Band — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-order-band.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-reviews-section/duccinis-reviews-section.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-reviews-section/duccinis-reviews-section.component.yml
@@ -40,3 +40,10 @@ third_party_settings:
   canvas:
     label: 'Reviews Section — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-reviews-section.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-story-section/duccinis-story-section.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-story-section/duccinis-story-section.component.yml
@@ -38,3 +38,10 @@ third_party_settings:
   canvas:
     label: 'Story Section — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-story-section.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-stripe-separator/duccinis-stripe-separator.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-stripe-separator/duccinis-stripe-separator.component.yml
@@ -15,3 +15,10 @@ third_party_settings:
   canvas:
     label: 'Stripe Separator — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-stripe-separator.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-ticker/duccinis-ticker.component.yml
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-ticker/duccinis-ticker.component.yml
@@ -18,3 +18,10 @@ third_party_settings:
   canvas:
     label: 'Ticker — Duccinis'
     category: Duccinis
+
+libraryOverrides:
+  css:
+    theme:
+      duccinis-ticker.css: {}
+  dependencies:
+    - duccinis_1984_olympics/style


### PR DESCRIPTION
Closes #211

## What changed
Added `libraryOverrides` to all 9 `duccinis-*` SDC component YAML files:

- Moved component CSS from the `component` CSS group to the `theme` group
- Declared `duccinis_1984_olympics/style` as an explicit library dependency

## Why
Drupal loads CSS files in group order: base → layout → component → state → theme. `main.style.css` (which defines all `--duccini-*` CSS custom properties in a `:root` block) is in the `theme` group. Without this fix, SDC component CSS (auto-assigned to the `component` group) was loaded **before** `main.style.css` in the page source.

By moving component CSS to `theme` group and declaring `duccinis_1984_olympics/style` as a dependency, Drupal now guarantees: **`main.style.css` → component CSS** within the same CSS group batch.

## Acceptance criteria verification
- ✅ All `--duccini-*` tokens have confirmed values in `main.style.css`:
  - `--duccini-blue: #0077C0`, `--duccini-pink: #D62976`, `--duccini-gold: #FFC914`, `--duccini-orange: #FF6B35`, `--duccini-red: #E63946`, `--duccini-dark: #1a1a1a`, `--duccini-border: #e5e7eb`, `--duccini-bg: #fafafa`
- ✅ No component defines fallback values — all use `var(--duccini-*)` which resolves from `:root`
- ✅ `main.style.css` confirmed loaded before all component CSS in page source (verified with curl smoke test, CSS aggregation off)