### PR TITLE
fix: close issue #251 — render .site-nav on front page, suppress Bootstrap navbar

### DIFF
--- a/web/themes/custom/duccinis_1984_olympics/templates/page/page--front.html.twig
+++ b/web/themes/custom/duccinis_1984_olympics/templates/page/page--front.html.twig
@@ -1,45 +1,52 @@
 {#
 /**
  * @file
- * Theme override to display a single page.
+ * Front page override — replaces the Radix Bootstrap navbar with the custom
+ * .site-nav structure from the 1984 Olympics design system.
  *
- * The doctype, html, head and body tags are not in this template. Instead they
- * can be found in the html.html.twig template in this directory.
+ * Deliberately does NOT delegate to radix:page because radix:page-navigation
+ * always renders a Bootstrap navbar. The homepage uses a bespoke fixed nav
+ * with a text logo, anchor links, and a clip-path "Order Now" button.
  *
- * Available variables:
+ * The radix:page-content container wrapper is also bypassed — homepage SDC
+ * sections own all their own spacing; no container or py-5 should wrap them.
  *
- * General utility variables:
- * - base_path: The base URL path of the Drupal installation. Will usually be
- *   "/" unless you have installed Drupal in a sub-directory.
- * - is_front: A flag indicating if the current page is the front page.
- * - logged_in: A flag indicating if the user is registered and signed in.
- * - is_admin: A flag indicating if the user has permission to access
- *   administration pages.
- *
- * Site identity:
- * - front_page: The URL of the front page. Use this instead of base_path when
- *   linking to the front page. This includes the language domain or prefix.
- *
- * Page content (in order of occurrence in the default page.html.twig):
- * - node: Fully loaded node, if there is an automatically-loaded node
- *   associated with the page and the node ID is the second argument in the
- *   page's path (e.g. node/12345 and node/12345/revisions, but not
- *   comment/reply/12345).
- *
- * Regions:
- * - page.header: Items for the header region.
- * - page.primary_menu: Items for the primary menu region.
- * - page.secondary_menu: Items for the secondary menu region.
- * - page.highlighted: Items for the highlighted content region.
- * - page.help: Dynamic help text, mostly for admin pages.
- * - page.content: The main content of the current page.
- * - page.sidebar_first: Items for the first sidebar.
- * - page.sidebar_second: Items for the second sidebar.
- * - page.footer: Items for the footer region.
- * - page.breadcrumb: Items for the breadcrumb region.
- *
+ * @see web/themes/custom/duccinis_1984_olympics/src/scss/components/_homepage.scss
+ * @see web/themes/custom/duccinis_1984_olympics/src/js/homepage-reveal.js
  * @see template_preprocess_page()
- * @see html.html.twig
  */
 #}
-{% include 'radix:page' %}
+<div class="page page--front">
+
+  {# ── Custom site navigation ────────────────────────────────────────────── #}
+  {# Replaces Bootstrap radix:page-navigation. Fixed, dark, blur backdrop.   #}
+  <nav class="site-nav" id="site-nav" aria-label="{{ 'Main navigation'|t }}">
+    <a href="{{ path('<front>') }}" class="nav-logo">DUCCI<em>NI'S</em></a>
+    <ul class="nav-links" role="list">
+      <li><a href="#locations">{{ 'Locations'|t }}</a></li>
+      <li><a href="#story">{{ 'About'|t }}</a></li>
+      <li><a href="#reviews">{{ 'Reviews'|t }}</a></li>
+    </ul>
+    <a href="/menu" class="nav-order clip-sm">{{ 'Order Now'|t }}</a>
+  </nav>
+
+  {# ── Page content — homepage SDC sections ─────────────────────────────── #}
+  <main id="main-content">
+    {{ page.content }}
+  </main>
+
+  {# ── Footer region ─────────────────────────────────────────────────────── #}
+  {% if page.footer %}
+    <footer class="page__footer">
+      <div class="container">
+        {{ page.footer }}
+      </div>
+    </footer>
+  {% endif %}
+
+  {# ── Page bottom (Drupal scripting region) ────────────────────────────── #}
+  {% if page.page_bottom %}
+    {{ page.page_bottom }}
+  {% endif %}
+
+</div>


### PR DESCRIPTION
Closes #251

## What changed
Overrides `page--front.html.twig` to directly emit the custom `<nav class="site-nav">` structure rather than delegating to `radix:page`, which always renders the Bootstrap navbar via `radix:page-navigation`.

## Acceptance criteria verified (live smoke test)
- ✅ `<nav class="site-nav" id="site-nav">` renders on the front page
- ✅ Logo: `DUCCI<em>NI'S</em>` with `.nav-logo` class (Bebas Neue, no image)
- ✅ Nav links: Locations · About · Reviews with correct `#anchor` targets
- ✅ `Order Now` button with `.nav-order.clip-sm` links to `/menu`
- ✅ `navScroll` behavior attaches (existing `homepage-reveal.js` targets `.site-nav`)
- ✅ Bootstrap `navbar` no longer rendered on the front page
- ✅ Homepage SDC sections unaffected (`duccinis-hero`, `duccinis-ticker`, etc.)
- ✅ No SCSS/JS changes required — all styles/behaviors already existed