### PR TITLE
feat(#248,#249): remove hardcoded Twig defaults — reviews and story sections

### DIFF
--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-reviews-section/duccinis-reviews-section.twig
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-reviews-section/duccinis-reviews-section.twig
@@ -8,27 +8,7 @@
  *   reviews (array<{text, author, source, stars}>)
  */
 #}
-{% set default_reviews = [
-  {
-    text: "This place is a no-bs pillar of the community. The pizza is always on point. Friendliest staff on U Street — somehow always quick with a smile no matter how busy it gets.",
-    author: 'Haytham Hashem',
-    source: 'Google Review · Adams Morgan',
-    stars: 5,
-  },
-  {
-    text: "One of the few non-chain pizza places that actually puts black olives on pizzas in DC! Great sauce, well-balanced crust — the right mix of sweet, chewy, and crunchy.",
-    author: 'Joey Minervini',
-    source: 'Google Review · Adams Morgan',
-    stars: 5,
-  },
-  {
-    text: "My number one pizza place! Open till 5am — I drive all the way from Fairfax just for the jumbo slice. Never waiting more than 3 minutes. Always a must-stop.",
-    author: 'Cynthia Garman',
-    source: 'Google Review · Multiple Locations',
-    stars: 5,
-  },
-] %}
-{% set review_items = reviews is defined and reviews is not empty ? reviews : default_reviews %}
+{% set review_items = reviews is defined and reviews is not empty ? reviews : [] %}
 <section class="duccinis-reviews-section" id="reviews"
   aria-labelledby="reviews-section-title">
   <div class="duccinis-reviews-section__container">

--- a/web/themes/custom/duccinis_1984_olympics/components/duccinis-story-section/duccinis-story-section.twig
+++ b/web/themes/custom/duccinis_1984_olympics/components/duccinis-story-section/duccinis-story-section.twig
@@ -9,18 +9,8 @@
  *   stats (array<{number, label}>)
  */
 #}
-{% set default_paragraphs = [
-  "Duccini's is credited with developing Washington DC's very first New York-style jumbo slice pizza. Since 1988, we've intentionally kept our footprint small to stay laser-focused on what matters most: flavor, quality, and community.",
-  "Everything is made from scratch every single day, using only the freshest ingredients. Friendly faces, no waiting, and a slice big enough to fold in half — that's the Duccini's promise. DC's best slice, every time.",
-] %}
-{% set default_stats = [
-  {number: '37+', label: 'Years in Business'},
-  {number: '3',   label: 'DMV Locations'},
-  {number: '#1',  label: 'Original Jumbo Slice'},
-  {number: '5★',  label: 'Google Reviews'},
-] %}
-{% set story_paragraphs = paragraphs is defined and paragraphs is not empty ? paragraphs : default_paragraphs %}
-{% set story_stats = stats is defined and stats is not empty ? stats : default_stats %}
+{% set story_paragraphs = paragraphs is defined and paragraphs is not empty ? paragraphs : [] %}
+{% set story_stats = stats is defined and stats is not empty ? stats : [] %}
 <section class="duccinis-story-section" id="story"
   aria-labelledby="story-section-title">
   <div class="duccinis-story-section__container">


### PR DESCRIPTION
Closes #248. Closes #249. Removes hardcoded default arrays from `duccinis-reviews-section` and `duccinis-story-section` Twig templates. Both now fall back to empty arrays, forcing Canvas to be the single source of truth for content. Manual step required: populate props via Canvas editor before deploying to production.