### PR TITLE
Fix #272: Show product title in cart Item column instead of price

### DIFF
--- a/config/sync/core.entity_view_display.commerce_product_variation.default.cart.yml
+++ b/config/sync/core.entity_view_display.commerce_product_variation.default.cart.yml
@@ -18,25 +18,17 @@ targetEntityType: commerce_product_variation
 bundle: default
 mode: cart
 content:
-  list_price:
-    label: above
-    type: commerce_price_default
-    weight: -1
-    region: content
-    settings:
-      strip_trailing_zeroes: false
-      currency_display: symbol
-    third_party_settings: {  }
-  product_id:
-    type: entity_reference_label
-    weight: 0
+  title:
+    type: string
     label: hidden
     settings:
-      link: true
+      link_to_entity: false
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   add_to_cart_link: true
+  list_price: true
   price: true
+  product_id: true
   sku: true
-  title: true


### PR DESCRIPTION
## Bug Report

**URL:** `/cart`

**Problem:**
The Item column on the `/cart` page displays `Price $10.99` instead of the product/variation title. Customers cannot identify what is in their shopping cart.

**Root Cause:**
The `commerce_product_variation.default.cart` entity view display has `title` in the `hidden` section and renders `list_price` in the content region instead.

**Fix:**
Update `config/sync/core.entity_view_display.commerce_product_variation.default.cart.yml` to move `title` into the `content` section and hide `list_price`.

**Acceptance Criteria:**
- [ ] `/cart` Item column shows the product/variation title (e.g. "Pepperoni Pizza")
- [ ] Price is no longer shown in the Item column
- [ ] Config exported and committed
